### PR TITLE
fix(web): bootstrap signed-in state on auth transitions

### DIFF
--- a/web/src/lib/bootstrap.test.ts
+++ b/web/src/lib/bootstrap.test.ts
@@ -1,0 +1,83 @@
+// Verifies that the post-sign-in bootstrap fans out the side effects the
+// signed-in shell relies on (project list, WS connection, initial-load
+// handoff). The bug it pins: if these only run inside the layout's
+// onMount, a user who lands on /setup or /login and then signs in lives
+// in a half-bootstrapped state until they refresh the tab.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { connectMock } = vi.hoisted(() => ({ connectMock: vi.fn() }));
+vi.mock('./ws', () => ({ connect: connectMock, disconnect: vi.fn() }));
+
+import { api } from './api';
+import { bootstrapSignedIn } from './bootstrap';
+import { load, projects } from './stores.svelte';
+import type { ProjectSummary } from './types';
+
+const summary = (over: Partial<ProjectSummary>): ProjectSummary => ({
+  project: 'p',
+  issue_count: 0,
+  ...over
+});
+
+beforeEach(() => {
+  projects.available = [];
+  projects.current = 'default';
+  load.initialLoad = true;
+  connectMock.mockReset();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('bootstrapSignedIn', () => {
+  it('populates projects.available and connects to the first project', async () => {
+    const summaries = [summary({ project: 'foo' }), summary({ project: 'bar' })];
+    vi.spyOn(api, 'projects').mockResolvedValue(summaries);
+
+    await bootstrapSignedIn();
+
+    expect(projects.available).toEqual(summaries);
+    expect(connectMock).toHaveBeenCalledWith('foo');
+  });
+
+  it('connects to projects.current when the daemon has zero projects', async () => {
+    // Fresh-install path: api.projects() resolves with [], so the bootstrap
+    // still has to bring up the WS so the eventual snapshot can flip
+    // load.initialLoad → false.
+    vi.spyOn(api, 'projects').mockResolvedValue([]);
+    projects.current = 'default';
+
+    await bootstrapSignedIn();
+
+    expect(projects.available).toEqual([]);
+    expect(connectMock).toHaveBeenCalledWith('default');
+  });
+
+  it('falls back to projects.current when /api/projects fails', async () => {
+    // Daemon transient error must not leave the UI un-connected — the WS
+    // still comes up against the last known project, and the user sees the
+    // toast surface the failure.
+    vi.spyOn(api, 'projects').mockRejectedValue(new Error('network'));
+    projects.current = 'staging';
+
+    await bootstrapSignedIn();
+
+    expect(connectMock).toHaveBeenCalledWith('staging');
+  });
+
+  it('clears load.initialLoad after the 4s fallback', async () => {
+    // The WS snapshot is the primary signal that flips initialLoad; the
+    // setTimeout is a safety net for daemons that never deliver a snapshot.
+    vi.spyOn(api, 'projects').mockResolvedValue([]);
+
+    await bootstrapSignedIn();
+
+    expect(load.initialLoad).toBe(true);
+    vi.advanceTimersByTime(4_000);
+    expect(load.initialLoad).toBe(false);
+  });
+});

--- a/web/src/lib/bootstrap.ts
+++ b/web/src/lib/bootstrap.ts
@@ -1,0 +1,38 @@
+// Side effects that have to fire whenever the operator becomes signed
+// in — whether that's the cookie hydrating on page load, or a fresh
+// /setup or /login completing within the same tab. Keeping this out of
+// `+layout.svelte`'s `onMount` matters because the layout is the
+// outermost shell: it mounts once per tab. If the bootstrap lived in
+// onMount and the tab opened on /setup (signed_out at hydrate time), a
+// successful setup would never bring up the project list or the WS, and
+// the / page would forever sit on its skeleton.
+
+import { api } from './api';
+import { load, projects } from './stores.svelte';
+import { toast } from './toast.svelte';
+import { connect } from './ws';
+
+const INITIAL_LOAD_FALLBACK_MS = 4_000;
+
+export async function bootstrapSignedIn(): Promise<void> {
+  try {
+    const summaries = await api.projects();
+    projects.available = summaries;
+    const initial = summaries[0]?.project ?? projects.current ?? 'default';
+    connect(initial);
+  } catch (err) {
+    console.warn('failed to load projects', err);
+    toast.error('Could not load projects', {
+      description: 'Check that errexd is reachable.'
+    });
+    connect(projects.current);
+  }
+
+  // Safety net: the WS snapshot is the primary signal that flips
+  // initialLoad to false (see ws.ts). This timeout covers the case where
+  // the daemon never delivers a snapshot — without it, the issues view
+  // sits on the skeleton forever.
+  setTimeout(() => {
+    load.initialLoad = false;
+  }, INITIAL_LOAD_FALLBACK_MS);
+}

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -7,6 +7,7 @@
   import { AlertCircle, LogOut, Search, Settings, Users } from 'lucide-svelte';
   import { actions } from '$lib/actions.svelte';
   import { auth } from '$lib/auth.svelte';
+  import { bootstrapSignedIn } from '$lib/bootstrap';
   import CommandPalette from '$lib/components/CommandPalette.svelte';
   import ConnectionStatus from '$lib/components/ConnectionStatus.svelte';
   import Freshness from '$lib/components/Freshness.svelte';
@@ -16,11 +17,9 @@
   import Toaster from '$lib/components/Toaster.svelte';
   import { Button } from '$lib/components/ui/button';
   import * as Tooltip from '$lib/components/ui/tooltip';
-  import { api } from '$lib/api';
-  import { load, projects } from '$lib/stores.svelte';
   import { toast } from '$lib/toast.svelte';
   import { cn } from '$lib/utils';
-  import { connect, disconnect } from '$lib/ws';
+  import { disconnect } from '$lib/ws';
 
   let { children } = $props();
 
@@ -73,28 +72,23 @@
   onMount(async () => {
     actions.hydrate();
     await auth.hydrate();
+    // The bootstrap fires from the $effect below — that path covers both
+    // "valid cookie on first paint" and "user signs in within this tab".
+  });
 
-    // Skip the issues / WS bootstrap if we're not signed in. The redirect
-    // effect will land us on /login first; we re-run this on mount of the
-    // signed-in shell anyway.
-    if (auth.status !== 'signed_in') return;
-
-    try {
-      const summaries = await api.projects();
-      projects.available = summaries;
-      const initial = summaries[0]?.project ?? projects.current ?? 'default';
-      connect(initial);
-    } catch (err) {
-      console.warn('failed to load projects', err);
-      toast.error('Could not load projects', {
-        description: 'Check that errexd is reachable.'
-      });
-      connect(projects.current);
+  // Run the signed-in bootstrap once per signed-in user. Keying on the
+  // username lets a logout → re-login (potentially as a different user)
+  // re-fetch projects and reconnect the WS, while a status flap with the
+  // same user is a no-op.
+  let bootstrappedFor = $state<string | null>(null);
+  $effect(() => {
+    const username = auth.status === 'signed_in' ? (auth.user?.username ?? null) : null;
+    if (username && bootstrappedFor !== username) {
+      bootstrappedFor = username;
+      void bootstrapSignedIn();
+    } else if (auth.status === 'signed_out') {
+      bootstrappedFor = null;
     }
-
-    setTimeout(() => {
-      load.initialLoad = false;
-    }, 4_000);
   });
 
   onDestroy(() => disconnect());
@@ -105,15 +99,22 @@
   }
 </script>
 
-{#if onAuthRoute}
-  <!-- Full-screen routes (login/setup) draw their own chrome. -->
-  {@render children?.()}
-{:else if auth.status === 'unknown' || auth.status === 'signed_out'}
-  <!-- Brief flash while the auth-gate effect routes the user. Showing the
-       sign-in card here for a frame is worse than a blank screen. -->
-  <div class="bg-background h-screen"></div>
-{:else}
-  <Tooltip.Provider delayDuration={0}>
+<!-- Tooltip.Provider must wrap every children-rendering branch: during
+     a setup→/ or login→/ navigation, SvelteKit can swap `children` to the
+     new route's +page.svelte before $page.url.pathname propagates, so for
+     a frame we render signed-in content under the auth-route branch. If
+     Tooltip.Provider lived only inside the signed-in branch, that frame
+     would crash with "Context Tooltip.Provider not found" and leave the
+     transition wedged. -->
+<Tooltip.Provider delayDuration={0}>
+  {#if onAuthRoute}
+    <!-- Full-screen routes (login/setup) draw their own chrome. -->
+    {@render children?.()}
+  {:else if auth.status === 'unknown' || auth.status === 'signed_out'}
+    <!-- Brief flash while the auth-gate effect routes the user. Showing the
+         sign-in card here for a frame is worse than a blank screen. -->
+    <div class="bg-background h-screen"></div>
+  {:else}
     <div class="flex h-screen">
       <aside
         class="border-border bg-background flex w-14 shrink-0 flex-col items-center gap-3 border-r py-4"
@@ -259,8 +260,8 @@
         </main>
       </div>
     </div>
-  </Tooltip.Provider>
-{/if}
+  {/if}
+</Tooltip.Provider>
 
 <Toaster />
 <CommandPalette open={paletteOpen} onClose={() => (paletteOpen = false)} />


### PR DESCRIPTION
## Summary
- After Create Admin on `/setup`, the operator stayed wedged on `/` instead of landing on `/projects`. Same hole affected `/login` on a fresh daemon, and a `Tooltip.Provider not found` render crash during the navigation made the page silently un-recoverable.
- Bootstrap (project list, WS connect, `load.initialLoad` 4s safety net) is moved out of `+layout.svelte`'s `onMount` into `lib/bootstrap.ts`, fired by a `$effect` keyed on `auth.user.username`. Re-login as a different user re-bootstraps; same-user status flaps are no-ops.
- `Tooltip.Provider` is hoisted above the `{#if onAuthRoute}` / `{:else if signed_out}` / `{:else}` cascade so children always render inside its context, even during the brief moment SvelteKit swaps `children` before `$page.url.pathname` propagates.

## Test plan
- [x] `bun run check` (svelte-check) — 0 errors / 0 warnings
- [x] `bun run test` — 106 tests, 11 files green; new `bootstrap.test.ts` covers happy path, empty-daemon, API failure fallback, and the 4s `load.initialLoad` safety net
- [x] Live smoke via Chrome over MCP against a throwaway daemon (alt ports 9095/9096, `ERREXD_ADMIN_TOKEN=…`): `/setup` → token → `Create Admin` lands on `/projects` with `Create your first project` hero and no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)