### PR TITLE
fix(docker): named volume for /data so first-run works on any host

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,8 +11,16 @@ services:
       - "9091:9091"
       - "9092:9092"
     volumes:
-      - ../data:/data
+      # Named volume so /data inherits the image's UID 1000 ownership.
+      # A host bind (e.g. ../data:/data) clobbers those perms with the host
+      # dir's owner, which makes SQLite fail to open the DB on any host
+      # whose UID isn't 1000. Power users who want a host-path bind should
+      # pre-create the dir with `chown 1000:1000` and swap this line.
+      - errex-data:/data
     environment:
       ERREXD_DATA_DIR: /data
       ERREXD_LOG_LEVEL: info
       ERREXD_ADMIN_TOKEN: ${ERREXD_ADMIN_TOKEN:-123}
+
+volumes:
+  errex-data:


### PR DESCRIPTION
## Summary

- Compose used a host bind (`../data:/data`) that inherited the host dir's ownership. The container runs as UID 1000 (distroless, set in the Dockerfile), so on any host whose user isn't UID 1000, SQLite failed with `unable to open database file (code 14)` on the first `docker compose up` — exactly the install path the README points at.
- Swap the bind for a named volume (`errex-data`). Docker initialises a named volume from the image, which already `--chown=1000:1000`'s `/data`, so perms are correct by construction with zero host-side setup.
- Inline comment on the volume points power users at the host-path-bind alternative (pre-create + `chown 1000:1000`).

## Why this matters

The README's "Install" section is literally `git clone && docker compose up -d`. That should work on any host. Today it only works if the cloning user happens to be UID 1000 (true on a default Linux dev box, false on macOS/colima, rootless docker, custom users, CI runners, etc.).

## Test plan

- [x] `docker compose -f docker/docker-compose.yml down -v` then `up -d` — container reaches `Up`, no SQLite errors in `docker logs errexd`, `curl http://localhost:9090/` serves the SPA.
- [x] Reproduced original failure first by running with the bind on a non-1000 host UID — got `unable to open database file (code 14)`. Confirmed the named-volume version fixes it.
- [ ] Existing users with data in `./data/` will need to either rename the volume or copy the SQLite file into the new volume — repo is alpha, so not handling migration here, but happy to add a `docs/MIGRATION.md` note if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)