### PR TITLE
fix(ci): give rust-embed a placeholder web/build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,16 @@ jobs:
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@v2
 
+      # rust-embed bundles web/build/ into the binary at compile time. CI
+      # has never run the SPA build, so the folder is missing and the macro
+      # can't resolve `Assets::get`. A placeholder satisfies the macro for
+      # the cargo gates (clippy/fmt/test never serve real assets); the prod
+      # build path runs the full `bun run build` in docker.
+      - name: Prepare SPA placeholder for rust-embed
+        run: |
+          mkdir -p web/build
+          touch web/build/index.html
+
       - name: fmt
         run: cargo fmt --all -- --check
 
@@ -54,8 +64,8 @@ jobs:
       - name: Install web deps
         run: bun install --frozen-lockfile
 
-      - name: svelte-check
-        run: bun run check
-
-      - name: vitest
-        run: bun run test
+      # `bun run ci` = check + test + build. Building here catches SPA-side
+      # regressions (svelte compile errors, missing types) that wouldn't
+      # surface in `check` or `test` alone.
+      - name: web ci (check + test + build)
+        run: bun run ci


### PR DESCRIPTION
## Summary
- Every CI run since the workflow landed failed in the rust job with \`error[E0599]: no function or associated item named 'get' found for struct 'spa::Assets'\` because \`crates/errexd/src/spa.rs\` derives \`RustEmbed\` on \`$CARGO_MANIFEST_DIR/../../web/build/\` and that folder doesn't exist on a fresh checkout.
- \`mkdir -p web/build && touch web/build/index.html\` before \`cargo fmt/clippy/test\` lets the macro resolve. The cargo gates never serve real assets — production builds the SPA in the docker stage that runs \`bun run build\` before cargo.
- Web job: swap \`bun run check\` + \`bun run test\` for \`bun run ci\` (= check + test + build) so SPA build regressions surface in CI too.

## Test plan
- [ ] Watch this PR's CI run go green (rust + web jobs both pass)
- [ ] Confirm the post-merge push to main also goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)