### PR TITLE
feat(web): inline test-event button with envelope-correct curl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ web/build
 # Local Claude Code / harness state — not for the public repo
 .claude/scheduled_tasks.lock
 .superpowers
+.worktrees
 
 # Local docker-compose overrides
 docker-compose.override.yml

--- a/docs/superpowers/plans/2026-04-26-test-event-button.md
+++ b/docs/superpowers/plans/2026-04-26-test-event-button.md
@@ -1,0 +1,389 @@
+# Test Event Button Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the "Copy a curl that sends a test event" link on `/projects/[name]` with a primary "Send test event" button that fires the test directly from the browser via `fetch`, while keeping the curl link as a small secondary affordance.
+
+**Architecture:** Pure-logic helper in `web/src/lib/testEvent.ts` owns the wire call and returns a tagged result; `ProjectDetail.svelte` owns the state machine (`idle | sending | sent`), toasts, and timer cleanup. Helper is unit-tested with mocked `fetch`; component is exercised manually + via the existing `bun run check` type-check pass. No server-side changes — the daemon's CORS layer (dev) and same-origin SPA (prod) already permit the browser to POST the project's DSN.
+
+**Tech Stack:** Svelte 5 runes, TypeScript strict, Vitest + jsdom, shadcn `Button`, `lucide-svelte` icons (`Send`, `Check`, `Loader2`), existing `toast` helper.
+
+**Spec:** `docs/superpowers/specs/2026-04-26-test-event-button-design.md`
+
+---
+
+## File Structure
+
+| File | Role |
+|---|---|
+| `web/src/lib/testEvent.ts` (new) | Pure async helper `sendTestEvent(dsn)`. Returns a tagged union — never throws, never touches DOM, never imports toast/Svelte. |
+| `web/src/lib/testEvent.test.ts` (new) | Vitest covering: request shape, 2xx OK, non-2xx tag with truncated body, network throw tag. |
+| `web/src/lib/components/ProjectDetail.svelte` (modify) | Replace the curl text-button with primary "Send test event" button + secondary "or copy as curl" link. Add `testStatus`, `revertHandle`, `sendTestEvent` handler. Reset both in the existing per-project effect at lines 50–58. |
+
+---
+
+## Task 1: Add the failing helper test
+
+**Files:**
+- Create: `web/src/lib/testEvent.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/src/lib/testEvent.test.ts`:
+
+```ts
+// Tests the wire-only helper used by the "Send test event" button on the
+// project detail page. The component owns the state machine and toasts;
+// this helper just talks to the ingest endpoint and reports what happened.
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { sendTestEvent } from './testEvent';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const DSN = 'http://localhost:9090/api/demo/envelope/?sentry_key=abc123';
+
+describe('sendTestEvent', () => {
+  it('POSTs the documented JSON body to the DSN', async () => {
+    const fetch = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => '',
+    } as Response);
+
+    await sendTestEvent(DSN);
+
+    expect(fetch).toHaveBeenCalledOnce();
+    const [url, init] = fetch.mock.calls[0]!;
+    expect(url).toBe(DSN);
+    expect(init?.method).toBe('POST');
+    expect((init?.headers as Record<string, string>)['content-type']).toBe(
+      'application/json'
+    );
+    expect(JSON.parse(init?.body as string)).toEqual({
+      event_id: 'test',
+      level: 'error',
+      message: 'errex test event',
+    });
+  });
+
+  it('returns { kind: "ok" } on a 2xx response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => '',
+    } as Response);
+
+    const result = await sendTestEvent(DSN);
+    expect(result).toEqual({ kind: 'ok' });
+  });
+
+  it('returns { kind: "http", status, body } on a non-2xx response, body truncated to 140 chars', async () => {
+    const longBody = 'x'.repeat(500);
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => longBody,
+    } as Response);
+
+    const result = await sendTestEvent(DSN);
+    expect(result).toEqual({
+      kind: 'http',
+      status: 401,
+      body: 'x'.repeat(140),
+    });
+  });
+
+  it('returns { kind: "network", error } when fetch throws', async () => {
+    const boom = new TypeError('Failed to fetch');
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(boom);
+
+    const result = await sendTestEvent(DSN);
+    expect(result).toEqual({ kind: 'network', error: boom });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd web && bun test testEvent`
+Expected: FAIL — `Cannot find module './testEvent'` (or similar import error). This is the right kind of "red".
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+cd /Users/r3g3n3r4/Projects/errex
+git add web/src/lib/testEvent.test.ts
+git commit -m "test: add failing helper tests for sendTestEvent"
+```
+
+---
+
+## Task 2: Implement the helper
+
+**Files:**
+- Create: `web/src/lib/testEvent.ts`
+
+- [ ] **Step 1: Write the minimal implementation**
+
+Create `web/src/lib/testEvent.ts`:
+
+```ts
+// Wire-only helper for the "Send test event" button on the project detail
+// page. Posts the same JSON shape the documented curl one-liner uses, so
+// browser-button parity with the curl path is exact. Returns a tagged
+// result; the component layers state machine, toasts, and timers on top.
+
+export type TestEventResult =
+  | { kind: 'ok' }
+  | { kind: 'http'; status: number; body: string }
+  | { kind: 'network'; error: unknown };
+
+const BODY_PREVIEW_LIMIT = 140;
+
+export async function sendTestEvent(dsn: string): Promise<TestEventResult> {
+  let res: Response;
+  try {
+    res = await fetch(dsn, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        event_id: 'test',
+        level: 'error',
+        message: 'errex test event',
+      }),
+    });
+  } catch (error) {
+    return { kind: 'network', error };
+  }
+
+  if (res.ok) return { kind: 'ok' };
+
+  const text = await res.text();
+  return {
+    kind: 'http',
+    status: res.status,
+    body: text.slice(0, BODY_PREVIEW_LIMIT),
+  };
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `cd web && bun test testEvent`
+Expected: PASS — all 4 cases green.
+
+- [ ] **Step 3: Run the full check gate**
+
+Run: `cd web && bun run check && bun test`
+Expected: type-check clean, full suite green.
+
+- [ ] **Step 4: Commit the implementation**
+
+```bash
+cd /Users/r3g3n3r4/Projects/errex
+git add web/src/lib/testEvent.ts
+git commit -m "feat(web): add sendTestEvent helper"
+```
+
+---
+
+## Task 3: Wire the button into ProjectDetail
+
+**Files:**
+- Modify: `web/src/lib/components/ProjectDetail.svelte`
+
+This task has no automated test — `ProjectDetail.svelte` is not currently
+covered by component tests, the spec explicitly does not introduce them
+for this change, and the wire call is already covered by Task 1. Manual
+verification happens in Task 4.
+
+- [ ] **Step 1: Add the imports**
+
+In `web/src/lib/components/ProjectDetail.svelte`, the existing icon import block at lines 2–11 already pulls `Check`, `Loader2`, `Send`. Add the helper import next to the other `$lib` imports (alphabetical block around line 30):
+
+```ts
+import { sendTestEvent } from '$lib/testEvent';
+```
+
+- [ ] **Step 2: Add the state declarations**
+
+Just after the existing `testingWebhook` declaration (around line 44):
+
+```ts
+let testStatus = $state<'idle' | 'sending' | 'sent'>('idle');
+let revertHandle = $state<ReturnType<typeof setTimeout> | null>(null);
+```
+
+- [ ] **Step 3: Reset on project switch**
+
+Inside the existing `$effect` at lines 50–58 (which already resets per-project state), add the reset right after `statsError = null;`:
+
+```ts
+testStatus = 'idle';
+if (revertHandle) {
+  clearTimeout(revertHandle);
+  revertHandle = null;
+}
+```
+
+- [ ] **Step 4: Add the handler**
+
+Just before the `// ----- rotate -----` comment (around line 188, after `testWebhook`), add:
+
+```ts
+async function sendTest() {
+  testStatus = 'sending';
+  if (revertHandle) {
+    clearTimeout(revertHandle);
+    revertHandle = null;
+  }
+  const result = await sendTestEvent(project.dsn);
+  if (result.kind === 'ok') {
+    testStatus = 'sent';
+    revertHandle = setTimeout(() => {
+      testStatus = 'idle';
+      revertHandle = null;
+    }, 2000);
+    return;
+  }
+  testStatus = 'idle';
+  if (result.kind === 'http') {
+    toast.error(`Ingest returned ${result.status}`, {
+      description: result.body || `HTTP ${result.status}`,
+    });
+  } else {
+    toast.error('Network error', { description: String(result.error) });
+  }
+}
+```
+
+- [ ] **Step 5: Replace the markup in the Connection section**
+
+Locate the existing block at lines 357–364 (the `<button onclick={copyCurl}>` with the "Copy a curl that sends a test event" label). Replace ONLY that `<button>` with this two-element block. Both interactive elements use the shadcn `Button` primitive — per project rules, no raw `<button>` in feature code:
+
+```svelte
+<div class="flex flex-col items-start gap-1.5">
+  <Button
+    variant="outline"
+    size="sm"
+    onclick={sendTest}
+    disabled={testStatus !== 'idle'}
+    aria-label="Send a test event to this project's ingest endpoint"
+    class={cn(testStatus === 'sent' && 'text-emerald-500 hover:text-emerald-500')}
+  >
+    {#if testStatus === 'sending'}
+      <Loader2 class="h-3.5 w-3.5 animate-spin" />
+      Sending…
+    {:else if testStatus === 'sent'}
+      <Check class="h-3.5 w-3.5" />
+      Sent
+    {:else}
+      <Send class="h-3.5 w-3.5" />
+      Send test event
+    {/if}
+  </Button>
+  <Button
+    variant="link"
+    size="sm"
+    onclick={copyCurl}
+    class="text-muted-foreground hover:text-foreground h-auto gap-1.5 px-0 text-[11px] hover:no-underline"
+  >
+    <ClipboardCopy class="h-3 w-3" />
+    or copy as curl
+  </Button>
+</div>
+```
+
+Notes on the second Button:
+- `variant="link"` is the link-shaped shadcn variant (no background, no border, inline-flex). Class overrides shrink it (`h-auto px-0`) and re-tint it to muted (the variant's default `text-primary` would read as a primary action — wrong here; this is a secondary affordance). `hover:no-underline` keeps it visually closer to the original muted text-link, since the variant's default `hover:underline` would be a louder hover than intended.
+- This intentionally also upgrades the existing curl-copy element from a raw `<button>` to the primitive, complying with the project's "shadcn primitives only" rule.
+
+- [ ] **Step 6: Type-check and run the suite**
+
+Run: `cd web && bun run check && bun test`
+Expected: type-check clean, full suite green (including the helper tests from Task 1).
+
+- [ ] **Step 7: Commit the wiring**
+
+```bash
+cd /Users/r3g3n3r4/Projects/errex
+git add web/src/lib/components/ProjectDetail.svelte
+git commit -m "feat(web): replace curl link with click-to-test button"
+```
+
+---
+
+## Task 4: Manual verification
+
+This is a UI change. Per CLAUDE.md, UI features must be exercised in a real browser before being declared done.
+
+- [ ] **Step 1: Boot the dev stack**
+
+Run (from repo root): `./scripts/dev.sh`
+Expected: daemon on `:9090`, Vite on `:5173`, both ready.
+
+- [ ] **Step 2: Visit a project detail page**
+
+Open `http://localhost:5173/projects/<some-project-name>` in a browser.
+Pick any project the seed script created, or create a fresh one via the projects list.
+
+- [ ] **Step 3: Verify idle state**
+
+Expected: Below the DSN code block you see the outline button "Send test event" with the send icon, and below it the small muted "or copy as curl" link. The previous "Copy a curl that sends a test event" text-link no longer appears.
+
+- [ ] **Step 4: Click "Send test event" — happy path**
+
+Expected sequence:
+1. Button shows spinner + "Sending…" briefly.
+2. Button morphs to green `Check` + "Sent" for ~2 s, then returns to idle.
+3. The activity sparkline above ticks within ~1 s (an `errex test event` issue gets created or its count bumps).
+4. No toast — success is the inline state and the sparkline tick.
+
+- [ ] **Step 5: Click "or copy as curl"**
+
+Expected: green "Test command copied" toast (existing behavior, unchanged). Button below it stays in `idle`. Pasting into a terminal still produces the same curl as before.
+
+- [ ] **Step 6: Force the error path**
+
+In DevTools → Network, set throttling to "Offline", then click "Send test event".
+Expected: button reverts to `idle`, red "Network error" toast appears with the `TypeError` message in the description.
+
+Restore network. In a separate tab, rotate the project's ingest token via the danger-zone Rotate flow but do NOT update the page (the in-memory `project.dsn` is now stale). Click "Send test event".
+Expected: button reverts to `idle`, red "Ingest returned 401" toast (or whatever status the daemon returns for an invalid token) with the truncated body in the description.
+
+If the rotate flow auto-refreshes `project.dsn` so the second case is hard to reproduce, edit `project.dsn` in the Svelte devtools or temporarily change the token portion to something invalid in the source — the goal is to land a non-2xx response.
+
+- [ ] **Step 7: Switch projects mid-flight**
+
+Click "Send test event" on project A, then immediately click project B in the rail (before the 2 s "Sent" timer expires).
+Expected: project B page loads in `idle` state. No stray "Sent" or "Sending…" labels carry over. (This validates the cleanup added in Task 3 Step 3.)
+
+- [ ] **Step 8: Mark the task complete**
+
+If all six checks above pass, the feature is verified. If any fails, return to Task 3 and fix; do not declare done.
+
+---
+
+## Self-Review
+
+**Spec coverage:** Every section of the spec has a corresponding task —
+UX shape (Task 3 Step 5), state machine (Task 3 Steps 2–4), behavior /
+fetch contract (Tasks 1 + 2), side-effect note about sparkline (Task 4
+Step 4), TDD helper (Tasks 1 + 2), out-of-scope items (none implemented,
+correctly absent). Timer cleanup explicitly handled in Task 3 Step 3 and
+Task 4 Step 7.
+
+**Placeholder scan:** No TBD/TODO. All file paths concrete. All commands
+runnable. All code blocks complete.
+
+**Type consistency:** `TestEventResult` shape matches between Task 1
+test assertions and Task 2 implementation. `testStatus` literal union
+matches between Task 3 Step 2 declaration, Step 4 handler assignments,
+and Step 5 markup conditionals (`'idle' | 'sending' | 'sent'`).
+`revertHandle` typed `ReturnType<typeof setTimeout> | null` consistently
+in Steps 2, 3, and 4.
+
+No issues found.

--- a/docs/superpowers/specs/2026-04-26-test-event-button-design.md
+++ b/docs/superpowers/specs/2026-04-26-test-event-button-design.md
@@ -1,0 +1,183 @@
+# Test event button on `/projects/[name]`
+
+**Date:** 2026-04-26
+**Surface:** `web/src/lib/components/ProjectDetail.svelte` (Connection · DSN section)
+
+## Problem
+
+Today, after creating a project the only "did it work?" affordance is a text
+link that copies a curl command to the clipboard:
+
+> *Copy a curl that sends a test event*
+
+The user then has to switch to a terminal, paste, run, and switch back to see
+the issue appear. That round-trip is the largest friction point in
+"new project → first event acknowledged" — it should be one click from the
+browser they are already in.
+
+## Goal
+
+Replace the curl link with a primary "Send test event" button that fires the
+test directly from the browser via `fetch`. Keep a small secondary "or copy
+as curl" link for the cross-machine / inside-a-container case where the user
+genuinely needs the shell command.
+
+Non-goal: simulating a real Sentry SDK envelope. The current curl posts
+`{"event_id":"test","level":"error","message":"errex test event"}`; the
+browser button posts the same payload to the same URL. Paridade total.
+
+## UX shape
+
+The Connection section (currently `ProjectDetail.svelte:352-365`) becomes:
+
+```
+Connection · DSN
+┌────────────────────────────────────────────┐
+│ <DsnSnippet />                             │
+└────────────────────────────────────────────┘
+[ ⏵ Send test event ]
+or copy as curl
+```
+
+- **Primary button** — `<Button variant="outline" size="sm">` with the
+  `Send` icon, label *"Send test event"*. Composes the existing shadcn
+  `Button` primitive at `web/src/lib/components/ui/button/`. No bespoke
+  styling.
+- **Secondary link** — same plain `<button>` that exists today, with the
+  label shortened to *"or copy as curl"* (was *"Copy a curl that sends a
+  test event"*). Same icon, same muted styling, same `copyCurl()` handler.
+  Sits directly under the primary button.
+
+### Button states
+
+Modeled on the existing `rotatedCopied` flow in this same component
+(`ProjectDetail.svelte:216-225, 491-510`). One piece of `$state` —
+`testStatus: 'idle' | 'sending' | 'sent'` — drives the visuals:
+
+| State | Icon | Label | Disabled | Notes |
+|---|---|---|---|---|
+| `idle` | `Send` | "Send test event" | no | default |
+| `sending` | `Loader2` (spin) | "Sending…" | yes | during fetch |
+| `sent` | `Check` | "Sent" | yes | green via `text-emerald-500` token; reverts to `idle` after 2000 ms |
+
+Errors do **not** introduce a separate visual state on the button. The
+button reverts to `idle` and a `toast.error(...)` describes the failure —
+matching how `testWebhook` already handles failures
+(`ProjectDetail.svelte:174-185`).
+
+## Behavior
+
+```ts
+async function sendTestEvent() {
+  testStatus = 'sending';
+  try {
+    const res = await fetch(project.dsn, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        event_id: 'test',
+        level: 'error',
+        message: 'errex test event',
+      }),
+    });
+    if (!res.ok) {
+      toast.error(`Ingest returned ${res.status}`, {
+        description: (await res.text()).slice(0, 140) || res.statusText,
+      });
+      testStatus = 'idle';
+      return;
+    }
+    testStatus = 'sent';
+    setTimeout(() => { testStatus = 'idle'; }, 2000);
+  } catch (err) {
+    toast.error('Network error', { description: String(err) });
+    testStatus = 'idle';
+  }
+}
+```
+
+Notes:
+
+- `project.dsn` is already the full ingest URL with `?sentry_key=…` baked
+  in (`crates/errexd/src/ingest.rs:261-268`). No URL construction needed
+  on the client.
+- CORS works in dev (the daemon allows `http://localhost:5173` when
+  `dev_mode` is on — `ingest.rs:133-147`) and in production the SPA is
+  same-origin. No new server-side change required.
+- The 2 s revert timer is owned by a dedicated `$effect` whose cleanup
+  function calls `clearTimeout`. Concretely: `sendTestEvent` sets
+  `testStatus = 'sent'` and stores the handle in
+  `let revertHandle = $state<ReturnType<typeof setTimeout> | null>(null)`;
+  an effect that depends on `revertHandle` returns a cleanup that clears
+  it. This guarantees the timer is killed when the component unmounts,
+  when the user switches projects (the existing project-switch effect at
+  `ProjectDetail.svelte:50-58` already resets per-project state — we
+  also reset `testStatus` to `idle` and `revertHandle` to `null` there),
+  or when a new send overwrites the handle.
+- No rate limiting. The existing webhook test button has none either, and
+  the ingest endpoint already deduplicates by fingerprint, so spam clicks
+  produce one issue with N occurrences — fine.
+
+## Side effects (intentional)
+
+A successful click creates (or bumps) an `errex test event` issue in the
+project. The activity sparkline on the same page ticks within ~1 s via the
+WS subscription that already drives this view. We do **not** add code to
+"watch for the tick" — the UI updates because the data updated. The
+inline `Sent ✓` confirmation is the explicit success signal; the sparkline
+tick is the ambient one.
+
+## Tests (TDD, frontend)
+
+Per the project's TDD rule, the new logic ships with `*.test.ts` tests.
+The fetch handler is the only piece worth covering — visuals are not in
+scope for snapshot tests.
+
+To make `sendTestEvent` testable in isolation it gets extracted to a pure
+helper alongside the component, at `web/src/lib/testEvent.ts`:
+
+```ts
+export async function sendTestEvent(dsn: string): Promise<
+  | { kind: 'ok' }
+  | { kind: 'http'; status: number; body: string }
+  | { kind: 'network'; error: unknown }
+>;
+```
+
+The component owns the state machine + toasts; the helper owns the wire
+call. Tests live at `web/src/lib/testEvent.test.ts` and cover, with
+`vi.spyOn(globalThis, 'fetch')`:
+
+1. POSTs to the given DSN with the documented JSON body and
+   `content-type: application/json`.
+2. Returns `{ kind: 'ok' }` on a 2xx response.
+3. Returns `{ kind: 'http', status, body }` on non-2xx, truncating body
+   to ≤140 chars to match the toast description.
+4. Returns `{ kind: 'network', error }` when `fetch` throws.
+
+No Rust changes. No new component tests beyond the helper — the existing
+`ProjectDetail.svelte` is not currently covered by component tests and
+this change does not warrant introducing them (visual states, no logic
+that isn't already in the helper).
+
+## What does not change
+
+- `copyCurl()` and the curl payload are untouched.
+- `testWebhook()` (the Slack/Discord webhook test) is untouched — it
+  already does the right thing.
+- No server-side, schema, or WS changes.
+- No new shadcn primitives. The button is `Button` from
+  `lib/components/ui/button`; the icons are existing `lucide-svelte`
+  imports already in this file (`Send`, `Check`, `Loader2`).
+
+## Out of scope
+
+- Rendering a richer success panel ("Event received — view in issues
+  list"). The sparkline tick + the issue appearing in the list is enough
+  signal at this size; adding a panel would mean reactively binding to
+  the WS event stream just for this confirmation, and that's the
+  overengineered (C) option we already discarded.
+- Sending an actual Sentry envelope from the browser. The endpoint
+  accepts both shapes and the simple JSON is fine for "did it arrive".
+- A toast on success. The inline `Sent ✓` is the success affordance;
+  doubling it with a toast would be noise.

--- a/web/src/lib/components/ProjectDetail.svelte
+++ b/web/src/lib/components/ProjectDetail.svelte
@@ -233,6 +233,11 @@
       toast.error(`Ingest returned ${result.status}`, {
         description: result.body || `HTTP ${result.status}`,
       });
+    } else if (result.kind === 'blocked') {
+      toast.error('Request blocked by browser', {
+        description:
+          'An ad blocker (uBlock Origin, etc.) blocked the test event. Disable it for this site, or use “or copy as curl” instead.',
+      });
     } else {
       toast.error('Network error', { description: String(result.error) });
     }
@@ -407,7 +412,7 @@
         Connection · DSN
       </Label>
       <DsnSnippet dsn={project.dsn} label={`DSN for ${project.name}`} />
-      <div class="flex flex-col items-start gap-1.5">
+      <div class="flex flex-row items-center gap-3">
         <Button
           variant="outline"
           size="sm"

--- a/web/src/lib/components/ProjectDetail.svelte
+++ b/web/src/lib/components/ProjectDetail.svelte
@@ -23,6 +23,7 @@
   import { Separator } from '$lib/components/ui/separator';
   import * as Tooltip from '$lib/components/ui/tooltip';
   import {
+    buildTestEventCurl,
     formatWebhookHealth,
     projectActivityStatus,
     validateNewProjectName
@@ -286,11 +287,7 @@
   let deleteOpen = $state(false);
 
   async function copyCurl() {
-    const cmd = [
-      `curl -X POST '${project.dsn}' \\`,
-      `  -H 'content-type: application/json' \\`,
-      `  -d '{"event_id":"test","level":"error","message":"errex test event"}'`
-    ].join('\n');
+    const cmd = buildTestEventCurl(project.dsn);
     try {
       await navigator.clipboard.writeText(cmd);
       toast.success('Test command copied');

--- a/web/src/lib/components/ProjectDetail.svelte
+++ b/web/src/lib/components/ProjectDetail.svelte
@@ -27,6 +27,7 @@
     projectActivityStatus,
     validateNewProjectName
   } from '$lib/projectsConsole';
+  import { sendTestEvent } from '$lib/testEvent';
   import { toast } from '$lib/toast.svelte';
   import { cn, relativeTime } from '$lib/utils';
   import type { ActivityStats, AdminProject } from '$lib/api';
@@ -42,6 +43,8 @@
   let webhookDraft = $state('');
   let savingWebhook = $state(false);
   let testingWebhook = $state(false);
+  let testStatus = $state<'idle' | 'sending' | 'sent'>('idle');
+  let revertHandle = $state<ReturnType<typeof setTimeout> | null>(null);
 
   // Reset draft + reload activity whenever the active project changes.
   // Without this, switching from "alpha" to "beta" in the rail would keep
@@ -53,6 +56,11 @@
       webhookDraft = project.webhook_url ?? '';
       stats = null;
       statsError = null;
+      testStatus = 'idle';
+      if (revertHandle) {
+        clearTimeout(revertHandle);
+        revertHandle = null;
+      }
       void refreshActivity();
     }
   });
@@ -182,6 +190,31 @@
       toast.error('Network error', { description: String(err) });
     } finally {
       testingWebhook = false;
+    }
+  }
+
+  async function sendTest() {
+    testStatus = 'sending';
+    if (revertHandle) {
+      clearTimeout(revertHandle);
+      revertHandle = null;
+    }
+    const result = await sendTestEvent(project.dsn);
+    if (result.kind === 'ok') {
+      testStatus = 'sent';
+      revertHandle = setTimeout(() => {
+        testStatus = 'idle';
+        revertHandle = null;
+      }, 2000);
+      return;
+    }
+    testStatus = 'idle';
+    if (result.kind === 'http') {
+      toast.error(`Ingest returned ${result.status}`, {
+        description: result.body || `HTTP ${result.status}`,
+      });
+    } else {
+      toast.error('Network error', { description: String(result.error) });
     }
   }
 
@@ -354,14 +387,36 @@
         Connection · DSN
       </Label>
       <DsnSnippet dsn={project.dsn} label={`DSN for ${project.name}`} />
-      <button
-        type="button"
-        onclick={copyCurl}
-        class="text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 self-start text-[11px] transition-colors"
-      >
-        <ClipboardCopy class="h-3 w-3" />
-        Copy a curl that sends a test event
-      </button>
+      <div class="flex flex-col items-start gap-1.5">
+        <Button
+          variant="outline"
+          size="sm"
+          onclick={sendTest}
+          disabled={testStatus !== 'idle'}
+          aria-label="Send a test event to this project's ingest endpoint"
+          class={cn(testStatus === 'sent' && 'text-emerald-500 hover:text-emerald-500')}
+        >
+          {#if testStatus === 'sending'}
+            <Loader2 class="h-3.5 w-3.5 animate-spin" />
+            Sending…
+          {:else if testStatus === 'sent'}
+            <Check class="h-3.5 w-3.5" />
+            Sent
+          {:else}
+            <Send class="h-3.5 w-3.5" />
+            Send test event
+          {/if}
+        </Button>
+        <Button
+          variant="link"
+          size="sm"
+          onclick={copyCurl}
+          class="text-muted-foreground hover:text-foreground h-auto gap-1.5 px-0 text-[11px] hover:no-underline"
+        >
+          <ClipboardCopy class="h-3 w-3" />
+          or copy as curl
+        </Button>
+      </div>
     </section>
 
     <Separator />

--- a/web/src/lib/components/ProjectDetail.svelte
+++ b/web/src/lib/components/ProjectDetail.svelte
@@ -32,6 +32,9 @@
   import { cn, relativeTime } from '$lib/utils';
   import type { ActivityStats, AdminProject } from '$lib/api';
 
+  // How long the "Sent" affordance lingers before reverting to "Send test event".
+  const SENT_REVERT_MS = 2000;
+
   type Props = { project: AdminProject };
   let { project }: Props = $props();
 
@@ -63,6 +66,17 @@
       }
       void refreshActivity();
     }
+  });
+
+  // Mirror the `pendingRefetch` cleanup pattern below: a dedicated $effect
+  // tracks revertHandle so the timer is killed on component unmount —
+  // otherwise navigating away mid-flight leaks a phantom 2s timer that
+  // holds a closure reference to the destroyed reactive scope.
+  $effect(() => {
+    const h = revertHandle;
+    return () => {
+      if (h) clearTimeout(h);
+    };
   });
 
   async function refreshActivity() {
@@ -194,18 +208,24 @@
   }
 
   async function sendTest() {
+    // Capture the project name at click time. If the user switches projects
+    // while the fetch is in flight, the in-flight result must NOT mutate
+    // testStatus on the now-active project — that would flash "Sent" on
+    // the wrong project's button.
+    const expectedProject = project.name;
     testStatus = 'sending';
     if (revertHandle) {
       clearTimeout(revertHandle);
       revertHandle = null;
     }
     const result = await sendTestEvent(project.dsn);
+    if (project.name !== expectedProject) return;
     if (result.kind === 'ok') {
       testStatus = 'sent';
       revertHandle = setTimeout(() => {
         testStatus = 'idle';
         revertHandle = null;
-      }, 2000);
+      }, SENT_REVERT_MS);
       return;
     }
     testStatus = 'idle';

--- a/web/src/lib/projectsConsole.test.ts
+++ b/web/src/lib/projectsConsole.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  buildTestEventCurl,
   formatWebhookHealth,
   isDeleteConfirmed,
   projectActivityStatus,
@@ -94,6 +95,70 @@ describe('isDeleteConfirmed', () => {
   it('rejects empty input even when project name is empty (defense in depth)', () => {
     expect(isDeleteConfirmed('', '')).toBe(false);
     expect(isDeleteConfirmed('   ', 'anything')).toBe(false);
+  });
+});
+
+describe('buildTestEventCurl', () => {
+  const DSN = 'http://localhost:9090/api/my-app/envelope/?sentry_key=tok123';
+  const FIXED = {
+    eventId: '00000000-0000-0000-0000-000000000001',
+    sentAt: '2026-04-26T12:00:00Z'
+  };
+
+  it('targets the DSN URL with POST', () => {
+    const cmd = buildTestEventCurl(DSN, FIXED);
+    expect(cmd).toMatch(/^curl -X POST '/);
+    expect(cmd).toContain(`'${DSN}'`);
+  });
+
+  it('sets the Sentry envelope content-type', () => {
+    const cmd = buildTestEventCurl(DSN, FIXED);
+    expect(cmd).toContain("-H 'content-type: application/x-sentry-envelope'");
+  });
+
+  it('uses --data-binary with $\'…\' so \\n stays literal in the body', () => {
+    // Plain `-d` collapses newlines on some shells; the envelope parser
+    // requires real newlines between header / item-header / payload.
+    const cmd = buildTestEventCurl(DSN, FIXED);
+    expect(cmd).toMatch(/--data-binary \$'/);
+  });
+
+  function extractBody(cmd: string): string {
+    const match = cmd.match(/--data-binary \$'([^']*)'/);
+    if (!match || match[1] === undefined) {
+      throw new Error(`expected --data-binary $'…' in: ${cmd}`);
+    }
+    return match[1];
+  }
+
+  it('emits exactly three newline-separated JSON lines: envelope header, item header, payload', () => {
+    const body = extractBody(buildTestEventCurl(DSN, FIXED));
+    // Trailing \n after the payload is part of the wire format. Splitting on \n
+    // therefore yields four parts where the last one is empty.
+    const parts = body.split('\\n');
+    expect(parts).toHaveLength(4);
+    expect(parts[3]).toBe('');
+
+    const envHeader = JSON.parse(parts[0] ?? '');
+    expect(envHeader.event_id).toBe(FIXED.eventId);
+    expect(envHeader.sent_at).toBe(FIXED.sentAt);
+
+    const itemHeader = JSON.parse(parts[1] ?? '');
+    expect(itemHeader.type).toBe('event');
+
+    const payload = JSON.parse(parts[2] ?? '');
+    expect(payload.level).toBe('error');
+    expect(payload.message).toMatch(/errex/i);
+    expect(payload.exception?.values?.[0]?.type).toBeDefined();
+  });
+
+  it('defaults eventId / sentAt when not provided (helper is callable in production)', () => {
+    const body = extractBody(buildTestEventCurl(DSN));
+    const envHeader = JSON.parse(body.split('\\n')[0] ?? '');
+    expect(envHeader.event_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    );
+    expect(() => new Date(envHeader.sent_at).toISOString()).not.toThrow();
   });
 });
 

--- a/web/src/lib/projectsConsole.test.ts
+++ b/web/src/lib/projectsConsole.test.ts
@@ -160,6 +160,18 @@ describe('buildTestEventCurl', () => {
     );
     expect(() => new Date(envHeader.sent_at).toISOString()).not.toThrow();
   });
+
+  it('escapes single quotes in the DSN so apostrophe-bearing project names do not break the shell quoting', () => {
+    // Project names may contain single quotes (e.g. "O'Brien"); the daemon
+    // embeds the name verbatim in the DSN, so without POSIX escaping the
+    // generated curl would be syntactically broken.
+    const dsn = "http://localhost:9090/api/O'Brien/envelope/?sentry_key=tok";
+    const cmd = buildTestEventCurl(dsn, FIXED);
+    // POSIX inside a single-quoted string: ' becomes '\''
+    expect(cmd).toContain("'http://localhost:9090/api/O'\\''Brien/envelope/?sentry_key=tok'");
+    // The naked apostrophe-flanked URL must NOT appear; that's the bug shape.
+    expect(cmd).not.toContain("'O'Brien");
+  });
 });
 
 describe('validateNewProjectName', () => {

--- a/web/src/lib/projectsConsole.ts
+++ b/web/src/lib/projectsConsole.ts
@@ -4,6 +4,8 @@
 // All time-dependent helpers take an explicit `now` (epoch ms) so tests
 // don't need to mock `Date.now`.
 
+import { ENVELOPE_CONTENT_TYPE, buildEnvelopeBody } from './testEvent';
+
 export type ProjectActivityStatus = {
   /** A Tailwind background class for the dot. */
   tone: string;
@@ -62,6 +64,22 @@ function formatRelative(diffMs: number): string {
  *  names ARE case-sensitive in errex). Empty input never matches. */
 export function isDeleteConfirmed(typed: string, projectName: string): boolean {
   return typed.trim().length > 0 && typed.trim() === projectName;
+}
+
+/** Builds a copy-pasteable curl that posts a Sentry envelope to the project's
+ *  ingest endpoint. The body comes from `buildEnvelopeBody` (shared with the
+ *  click-to-test button), wrapped in `$'…'` so the shell preserves the
+ *  literal newlines the parser requires. */
+export function buildTestEventCurl(
+  dsn: string,
+  opts: { eventId?: string; sentAt?: string } = {}
+): string {
+  const body = buildEnvelopeBody(opts).replace(/\n/g, '\\n');
+  return [
+    `curl -X POST '${dsn}' \\`,
+    `  -H 'content-type: ${ENVELOPE_CONTENT_TYPE}' \\`,
+    `  --data-binary $'${body}'`
+  ].join('\n');
 }
 
 /** Validation for the inline rename input. Mirrors the daemon's accepted

--- a/web/src/lib/projectsConsole.ts
+++ b/web/src/lib/projectsConsole.ts
@@ -75,11 +75,18 @@ export function buildTestEventCurl(
   opts: { eventId?: string; sentAt?: string } = {}
 ): string {
   const body = buildEnvelopeBody(opts).replace(/\n/g, '\\n');
+  // POSIX single-quote escape: project names allow apostrophes (e.g. "O'Brien"),
+  // and the daemon's DSN format embeds the name verbatim — without this, an
+  // apostrophe terminates the shell quoting and corrupts the request URL.
   return [
-    `curl -X POST '${dsn}' \\`,
+    `curl -X POST '${shellEscapeSingleQuoted(dsn)}' \\`,
     `  -H 'content-type: ${ENVELOPE_CONTENT_TYPE}' \\`,
     `  --data-binary $'${body}'`
   ].join('\n');
+}
+
+function shellEscapeSingleQuoted(value: string): string {
+  return value.replace(/'/g, "'\\''");
 }
 
 /** Validation for the inline rename input. Mirrors the daemon's accepted

--- a/web/src/lib/testEvent.test.ts
+++ b/web/src/lib/testEvent.test.ts
@@ -62,11 +62,33 @@ describe('sendTestEvent', () => {
     });
   });
 
-  it('returns { kind: "network", error } when fetch throws', async () => {
+  it('returns { kind: "network", error } when both the envelope fetch and the /health probe fail', async () => {
+    // mockRejectedValue (not mockRejectedValueOnce) → BOTH calls reject:
+    // first the envelope POST, then the /health probe. With the daemon
+    // genuinely unreachable, the helper falls through to the network kind.
     const boom = new TypeError('Failed to fetch');
     vi.spyOn(globalThis, 'fetch').mockRejectedValue(boom);
 
     const result = await sendTestEvent(DSN);
     expect(result).toEqual({ kind: 'network', error: boom });
+  });
+
+  it('returns { kind: "blocked" } when the envelope fetch fails but a /health probe succeeds', async () => {
+    // Adblockers (uBlock Origin et al.) match `/api/*/envelope/*` against
+    // their Sentry rules and reject the request with the same TypeError as
+    // a real network failure. We disambiguate by probing /health on the
+    // same origin — that path has no Sentry signature and gets through.
+    const boom = new TypeError('Failed to fetch');
+    const fetch = vi
+      .spyOn(globalThis, 'fetch')
+      .mockRejectedValueOnce(boom)
+      .mockResolvedValueOnce({ ok: true, status: 200 } as Response);
+
+    const result = await sendTestEvent(DSN);
+    expect(result).toEqual({ kind: 'blocked' });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    const probeUrl = fetch.mock.calls[1]![0];
+    expect(probeUrl).toBe('http://localhost:9090/health');
   });
 });

--- a/web/src/lib/testEvent.test.ts
+++ b/web/src/lib/testEvent.test.ts
@@ -1,0 +1,72 @@
+// Tests the wire-only helper used by the "Send test event" button on the
+// project detail page. The component owns the state machine and toasts;
+// this helper just talks to the ingest endpoint and reports what happened.
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { sendTestEvent } from './testEvent';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const DSN = 'http://localhost:9090/api/demo/envelope/?sentry_key=abc123';
+
+describe('sendTestEvent', () => {
+  it('POSTs the documented JSON body to the DSN', async () => {
+    const fetch = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => '',
+    } as Response);
+
+    await sendTestEvent(DSN);
+
+    expect(fetch).toHaveBeenCalledOnce();
+    const [url, init] = fetch.mock.calls[0]!;
+    expect(url).toBe(DSN);
+    expect(init?.method).toBe('POST');
+    expect((init?.headers as Record<string, string>)['content-type']).toBe(
+      'application/json'
+    );
+    expect(JSON.parse(init?.body as string)).toEqual({
+      event_id: 'test',
+      level: 'error',
+      message: 'errex test event',
+    });
+  });
+
+  it('returns { kind: "ok" } on a 2xx response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => '',
+    } as Response);
+
+    const result = await sendTestEvent(DSN);
+    expect(result).toEqual({ kind: 'ok' });
+  });
+
+  it('returns { kind: "http", status, body } on a non-2xx response, body truncated to 140 chars', async () => {
+    const longBody = 'x'.repeat(500);
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => longBody,
+    } as Response);
+
+    const result = await sendTestEvent(DSN);
+    expect(result).toEqual({
+      kind: 'http',
+      status: 401,
+      body: 'x'.repeat(140),
+    });
+  });
+
+  it('returns { kind: "network", error } when fetch throws', async () => {
+    const boom = new TypeError('Failed to fetch');
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(boom);
+
+    const result = await sendTestEvent(DSN);
+    expect(result).toEqual({ kind: 'network', error: boom });
+  });
+});

--- a/web/src/lib/testEvent.test.ts
+++ b/web/src/lib/testEvent.test.ts
@@ -3,7 +3,11 @@
 // this helper just talks to the ingest endpoint and reports what happened.
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { sendTestEvent } from './testEvent';
+import {
+  ENVELOPE_CONTENT_TYPE,
+  buildEnvelopeBody,
+  sendTestEvent,
+} from './testEvent';
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -12,7 +16,7 @@ afterEach(() => {
 const DSN = 'http://localhost:9090/api/demo/envelope/?sentry_key=abc123';
 
 describe('sendTestEvent', () => {
-  it('POSTs the documented JSON body to the DSN', async () => {
+  it('POSTs a Sentry envelope to the DSN with the envelope content-type', async () => {
     const fetch = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
       ok: true,
       status: 200,
@@ -26,12 +30,37 @@ describe('sendTestEvent', () => {
     expect(url).toBe(DSN);
     expect(init?.method).toBe('POST');
     expect((init?.headers as Record<string, string>)['content-type']).toBe(
-      'application/json'
+      ENVELOPE_CONTENT_TYPE
     );
-    expect(JSON.parse(init?.body as string)).toEqual({
-      event_id: 'test',
-      level: 'error',
-      message: 'errex test event',
+    // The daemon's `parse_envelope` requires three newline-separated JSON
+    // lines (envelope header, item header, payload) plus a trailing newline.
+    // Anything else returns 400 "invalid envelope". Lock that shape here.
+    const body = init?.body as string;
+    const parts = body.split('\n');
+    expect(parts).toHaveLength(4);
+    expect(parts[3]).toBe('');
+    expect(JSON.parse(parts[0] ?? '')).toMatchObject({
+      event_id: expect.any(String),
+      sent_at: expect.any(String),
+    });
+    expect(JSON.parse(parts[1] ?? '')).toEqual({ type: 'event' });
+    const payload = JSON.parse(parts[2] ?? '');
+    expect(payload.level).toBe('error');
+    expect(payload.message).toMatch(/errex/i);
+    expect(payload.exception?.values?.[0]?.type).toBeDefined();
+  });
+
+  it('buildEnvelopeBody produces deterministic output when given fixed eventId/sentAt', () => {
+    const body = buildEnvelopeBody({
+      eventId: '00000000-0000-0000-0000-000000000001',
+      sentAt: '2026-04-26T12:00:00Z',
+    });
+    expect(body.endsWith('\n')).toBe(true);
+    const parts = body.split('\n');
+    expect(parts).toHaveLength(4);
+    expect(JSON.parse(parts[0] ?? '')).toEqual({
+      event_id: '00000000-0000-0000-0000-000000000001',
+      sent_at: '2026-04-26T12:00:00Z',
     });
   });
 

--- a/web/src/lib/testEvent.ts
+++ b/web/src/lib/testEvent.ts
@@ -11,9 +11,11 @@ export type TestEventResult =
 const BODY_PREVIEW_LIMIT = 140;
 
 export async function sendTestEvent(dsn: string): Promise<TestEventResult> {
-  let res: Response;
+  // The catch covers both `fetch` rejection AND `res.text()` rejection —
+  // a body read can fail mid-stream (connection drop, CORS body restrictions,
+  // etc.) and the spec promises this helper never throws.
   try {
-    res = await fetch(dsn, {
+    const res = await fetch(dsn, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
@@ -22,16 +24,16 @@ export async function sendTestEvent(dsn: string): Promise<TestEventResult> {
         message: 'errex test event',
       }),
     });
+
+    if (res.ok) return { kind: 'ok' };
+
+    const text = await res.text();
+    return {
+      kind: 'http',
+      status: res.status,
+      body: text.slice(0, BODY_PREVIEW_LIMIT),
+    };
   } catch (error) {
     return { kind: 'network', error };
   }
-
-  if (res.ok) return { kind: 'ok' };
-
-  const text = await res.text();
-  return {
-    kind: 'http',
-    status: res.status,
-    body: text.slice(0, BODY_PREVIEW_LIMIT),
-  };
 }

--- a/web/src/lib/testEvent.ts
+++ b/web/src/lib/testEvent.ts
@@ -1,6 +1,6 @@
 // Wire-only helper for the "Send test event" button on the project detail
-// page. Posts the same JSON shape the documented curl one-liner uses, so
-// browser-button parity with the curl path is exact. Returns a tagged
+// page. Posts the same Sentry envelope the documented curl one-liner builds,
+// so browser-button parity with the curl path is exact. Returns a tagged
 // result; the component layers state machine, toasts, and timers on top.
 
 export type TestEventResult =
@@ -11,6 +11,31 @@ export type TestEventResult =
 
 const BODY_PREVIEW_LIMIT = 140;
 
+export const ENVELOPE_CONTENT_TYPE = 'application/x-sentry-envelope';
+
+/** Builds the three-line Sentry envelope body that errexd's ingest parser
+ *  expects: envelope header, item header, payload — newline-separated, with
+ *  a trailing newline after the payload. Pass `eventId` / `sentAt` for
+ *  deterministic tests; production callers leave them undefined. */
+export function buildEnvelopeBody(
+  opts: { eventId?: string; sentAt?: string } = {}
+): string {
+  const eventId = opts.eventId ?? randomUuid();
+  const sentAt = opts.sentAt ?? new Date().toISOString();
+  return [
+    JSON.stringify({ event_id: eventId, sent_at: sentAt }),
+    JSON.stringify({ type: 'event' }),
+    JSON.stringify({
+      level: 'error',
+      message: 'errex test event',
+      exception: {
+        values: [{ type: 'TestEvent', value: 'errex test event from curl' }],
+      },
+    }),
+    '',
+  ].join('\n');
+}
+
 export async function sendTestEvent(dsn: string): Promise<TestEventResult> {
   // The catch covers both `fetch` rejection AND `res.text()` rejection —
   // a body read can fail mid-stream (connection drop, CORS body restrictions,
@@ -18,12 +43,8 @@ export async function sendTestEvent(dsn: string): Promise<TestEventResult> {
   try {
     const res = await fetch(dsn, {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({
-        event_id: 'test',
-        level: 'error',
-        message: 'errex test event',
-      }),
+      headers: { 'content-type': ENVELOPE_CONTENT_TYPE },
+      body: buildEnvelopeBody(),
     });
 
     if (res.ok) return { kind: 'ok' };
@@ -52,4 +73,13 @@ async function isDaemonReachable(dsn: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+function randomUuid(): string {
+  // crypto.randomUUID is available in modern browsers and in jsdom 24+.
+  // Fall back to a v4-shaped string only if the environment stubs crypto out.
+  const c = typeof globalThis !== 'undefined' ? globalThis.crypto : undefined;
+  if (c && typeof c.randomUUID === 'function') return c.randomUUID();
+  const r = () => Math.floor(Math.random() * 0x10000).toString(16).padStart(4, '0');
+  return `${r()}${r()}-${r()}-${r()}-${r()}-${r()}${r()}${r()}`;
 }

--- a/web/src/lib/testEvent.ts
+++ b/web/src/lib/testEvent.ts
@@ -6,6 +6,7 @@
 export type TestEventResult =
   | { kind: 'ok' }
   | { kind: 'http'; status: number; body: string }
+  | { kind: 'blocked' }
   | { kind: 'network'; error: unknown };
 
 const BODY_PREVIEW_LIMIT = 140;
@@ -34,6 +35,21 @@ export async function sendTestEvent(dsn: string): Promise<TestEventResult> {
       body: text.slice(0, BODY_PREVIEW_LIMIT),
     };
   } catch (error) {
+    // Adblockers commonly match `/api/*/envelope/*` (Sentry signature) and
+    // reject with the same TypeError as a real offline failure. Probe a
+    // signature-free endpoint on the same origin to disambiguate: if the
+    // daemon answers, the envelope was specifically blocked client-side.
+    if (await isDaemonReachable(dsn)) return { kind: 'blocked' };
     return { kind: 'network', error };
+  }
+}
+
+async function isDaemonReachable(dsn: string): Promise<boolean> {
+  try {
+    const probe = new URL('/health', dsn).toString();
+    const res = await fetch(probe, { method: 'GET', cache: 'no-store' });
+    return res.ok;
+  } catch {
+    return false;
   }
 }

--- a/web/src/lib/testEvent.ts
+++ b/web/src/lib/testEvent.ts
@@ -1,0 +1,37 @@
+// Wire-only helper for the "Send test event" button on the project detail
+// page. Posts the same JSON shape the documented curl one-liner uses, so
+// browser-button parity with the curl path is exact. Returns a tagged
+// result; the component layers state machine, toasts, and timers on top.
+
+export type TestEventResult =
+  | { kind: 'ok' }
+  | { kind: 'http'; status: number; body: string }
+  | { kind: 'network'; error: unknown };
+
+const BODY_PREVIEW_LIMIT = 140;
+
+export async function sendTestEvent(dsn: string): Promise<TestEventResult> {
+  let res: Response;
+  try {
+    res = await fetch(dsn, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        event_id: 'test',
+        level: 'error',
+        message: 'errex test event',
+      }),
+    });
+  } catch (error) {
+    return { kind: 'network', error };
+  }
+
+  if (res.ok) return { kind: 'ok' };
+
+  const text = await res.text();
+  return {
+    kind: 'http',
+    status: res.status,
+    body: text.slice(0, BODY_PREVIEW_LIMIT),
+  };
+}


### PR DESCRIPTION
## Summary
- Replaces the curl-link affordance on the project detail page with an inline click-to-test button (state machine: idle → sending → sent), and a separate "Copy a curl that sends a test event" affordance for shell users.
- Both surfaces now emit a real Sentry envelope (`application/x-sentry-envelope`, three newline-separated JSON lines) — the previous raw-JSON shape was rejected by the daemon with `400 invalid envelope`.
- Adblock detection: when the envelope POST is blocked client-side (uBlock et al. match `/api/*/envelope/*`), a `/health` probe disambiguates network failure from blocking and surfaces a dedicated toast.
- Single-quote escape on the DSN before shell-interpolating into the curl, so apostrophe-containing project names don't corrupt the request URL.

## Test plan
- [x] `bun run check` clean
- [x] `bun run test` — 118/118 green (new coverage in `testEvent.test.ts`, `projectsConsole.test.ts`)
- [x] Live curl against the running daemon: generated command returns `HTTP/1.1 200 OK` (was `400 invalid envelope` on `main`)
- [ ] Manual: click "Send test event" on `/projects/<name>` and confirm it transitions idle → sending → sent and the event lands in the issue list
- [ ] Manual: enable an adblocker, click "Send test event", confirm the "blocked by extension" toast appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)