### PR TITLE
feat(web): swap projects nav icon from Settings to Boxes

### DIFF
--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -4,7 +4,7 @@
   import { onDestroy, onMount, setContext } from 'svelte';
   import { page } from '$app/stores';
   import { goto } from '$app/navigation';
-  import { AlertCircle, LogOut, Search, Settings, Users } from 'lucide-svelte';
+  import { AlertCircle, Boxes, LogOut, Search, Users } from 'lucide-svelte';
   import { actions } from '$lib/actions.svelte';
   import { auth } from '$lib/auth.svelte';
   import { bootstrapSignedIn } from '$lib/bootstrap';
@@ -159,7 +159,7 @@
                 )}
                 aria-label="Projects"
               >
-                <Settings class="h-[18px] w-[18px]" />
+                <Boxes class="h-[18px] w-[18px]" />
               </a>
             {/snippet}
           </Tooltip.Trigger>


### PR DESCRIPTION
## Summary

- Sidebar rail link to `/projects` used the `Settings` (cog) icon, which read as "app settings" instead of "your monitored apps."
- Swap to `Boxes` — projects in errex are the apps/repos you collect errors for, and the plural glyph matches the destination being a list view.

## Test plan

- [x] `bun run check` clean (TS + svelte-check).
- [x] Rebuilt the docker image and verified the icon renders in the sidebar at `localhost:9090` — tooltip ("Projects · DSN · webhooks") and route are unchanged.
- [ ] Pure visual change; no logic to unit-test (per CLAUDE.md frontend rules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)