### PR TITLE
fix(ws): unify HTTP+WS on :9090 via axum, idempotent connect()

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ scripts/                   dev.sh, smoke.sh, seed.sh
 The fast path uses Docker for the daemon and `bun run dev` for the SPA:
 
 ```bash
-./errex.sh up -d                              # daemon on :9090/:9091/:9092
+./errex.sh up -d                              # daemon on :9090 (HTTP+WS) and :9092 (MCP)
 (cd web && bun install && bun run dev)        # SPA on :5173 with HMR
 open http://localhost:5173
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,7 @@ checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core",
+ "base64",
  "bytes",
  "futures-util",
  "http",
@@ -158,8 +159,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite 0.24.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -518,7 +521,7 @@ dependencies = [
  "sqlx",
  "thiserror 1.0.69",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.21.0",
  "tower",
  "tower-http",
  "tracing",
@@ -2399,7 +2402,19 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.21.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.24.0",
 ]
 
 [[package]]
@@ -2555,6 +2570,24 @@ dependencies = [
  "sha1",
  "thiserror 1.0.69",
  "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.6",
+ "sha1",
+ "thiserror 1.0.69",
  "utf-8",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,11 @@ rust-version = "1.75"
 tokio = { version = "1.38", features = ["full"] }
 futures-util = "0.3"
 
-# HTTP / WebSocket
-axum = "0.7"
+# HTTP / WebSocket. axum's `ws` feature exposes WebSocketUpgrade so the
+# fan-out server shares the HTTP listener instead of opening a second port.
+# tokio-tungstenite stays in the dev-dep matrix for tests that drive the
+# server with a real client (and is still pulled in transitively).
+axum = { version = "0.7", features = ["ws"] }
 tokio-tungstenite = "0.21"
 tower = { version = "0.5", features = ["util"] }
 tower-http = { version = "0.6", features = ["trace", "cors", "fs"] }

--- a/crates/errexd/src/config.rs
+++ b/crates/errexd/src/config.rs
@@ -19,13 +19,6 @@ pub struct Config {
     #[arg(long, env = "ERREXD_HTTP_PORT", default_value_t = 9090)]
     pub http_port: u16,
 
-    /// Bind address for the WebSocket fan-out server (TUI clients).
-    #[arg(long, env = "ERREXD_WS_HOST", default_value = "0.0.0.0")]
-    pub ws_host: String,
-
-    #[arg(long, env = "ERREXD_WS_PORT", default_value_t = 9091)]
-    pub ws_port: u16,
-
     /// Bind address for the MCP server (AI agents). Stub for now.
     #[arg(long, env = "ERREXD_MCP_HOST", default_value = "0.0.0.0")]
     pub mcp_host: String,
@@ -90,12 +83,6 @@ impl Config {
         format!("{}:{}", self.http_host, self.http_port)
             .parse()
             .expect("valid http bind addr")
-    }
-
-    pub fn ws_addr(&self) -> SocketAddr {
-        format!("{}:{}", self.ws_host, self.ws_port)
-            .parse()
-            .expect("valid ws bind addr")
     }
 
     pub fn mcp_addr(&self) -> SocketAddr {

--- a/crates/errexd/src/ingest.rs
+++ b/crates/errexd/src/ingest.rs
@@ -1,8 +1,9 @@
 //! HTTP ingest + browser-facing API server.
 //!
-//! Serves three categories of routes off port 9090:
+//! Serves four categories of routes off port 9090:
 //!   - `/health`, `/api/:project/envelope/`     — operations + Sentry SDK ingest
 //!   - `/api/projects`, `/api/issues`           — JSON for the SPA
+//!   - `/ws/:project`                           — fan-out WebSocket (axum upgrade)
 //!   - everything else                          — embedded SvelteKit SPA
 //!
 //! Routing is intentionally flat so it's easy to add `/api/<project>/store/`
@@ -122,6 +123,11 @@ pub fn build_router(state: Arc<AppState>) -> Router {
             "/api/admin/users/:u/sessions/revoke-all",
             post(admin_revoke_user_sessions),
         )
+        // ----- websocket fan-out -----
+        // Must be a real route (not the SPA fallback) so the upgrade
+        // handshake gets `101 Switching Protocols` instead of `200 +
+        // index.html`. See crate::ws for the full background.
+        .route("/ws/:project", get(crate::ws::handle))
         .with_state(state)
         .fallback(spa::handler)
 }

--- a/crates/errexd/src/main.rs
+++ b/crates/errexd/src/main.rs
@@ -151,8 +151,9 @@ async fn main() -> anyhow::Result<()> {
         public_url: cfg.public_url.clone(),
         dev_mode: cfg.dev_mode,
     });
+    // The WS fan-out is mounted on the HTTP listener via axum (see
+    // crate::ws), so there's no separate task to spawn here.
     let http_handle = tokio::spawn(ingest::serve(cfg.http_addr(), http_state));
-    let ws_handle = tokio::spawn(ws::serve(cfg.ws_addr(), store.clone(), fanout_tx.clone()));
     let mcp_handle = tokio::spawn(mcp::serve(cfg.mcp_addr()));
     let retention_handle = {
         let store = store.clone();
@@ -161,16 +162,14 @@ async fn main() -> anyhow::Result<()> {
     };
 
     tracing::info!(
-        "errexd listening on :{} (http), :{} (ws), :{} (mcp)",
+        "errexd listening on :{} (http+ws), :{} (mcp)",
         cfg.http_port,
-        cfg.ws_port,
         cfg.mcp_port,
     );
 
     // Block on either Ctrl-C or any subsystem error.
     tokio::select! {
         res = http_handle => res.context("http task panicked")?.context("http server")?,
-        res = ws_handle => res.context("ws task panicked")?.context("ws server")?,
         res = mcp_handle => res.context("mcp task panicked")?.context("mcp server")?,
         res = digest_handle => res.context("digest task panicked")?.context("digest")?,
         res = retention_handle => res.context("retention task panicked")?,

--- a/crates/errexd/src/ws.rs
+++ b/crates/errexd/src/ws.rs
@@ -1,64 +1,62 @@
-//! WebSocket fan-out server for connected clients.
+//! WebSocket fan-out for connected SPA clients — mounted on the same axum
+//! listener as the HTTP API.
 //!
-//! On port 9091, separate from the HTTP ingest server. tokio-tungstenite
-//! directly is the smaller dep footprint vs axum's WS extractors.
+//! Earlier versions ran a separate tokio-tungstenite server on :9091. In
+//! production that broke the SPA: the browser builds the WS URL from
+//! `location.host`, which equals the HTTP port the SPA was served from.
+//! The upgrade request hit the HTTP listener, missed every API route, fell
+//! through to the SPA fallback, and got `200 + index.html` instead of
+//! `101 Switching Protocols`. Unifying onto one listener removes the
+//! whole class of "wrong port" bugs and shaves a TCP listener off the
+//! self-host footprint.
 //!
 //! Snapshot on connect comes from a SQLite query — there is no in-memory
 //! issue cache. WAL reads are sub-millisecond and skipping the cache saves
 //! `N × Issue` bytes for free. The cost is one query per connecting client,
 //! which is exactly when latency doesn't matter.
 
-use std::net::SocketAddr;
+use std::sync::Arc;
 
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::{Path, State};
+use axum::response::Response;
 use errex_proto::{ClientMessage, ServerMessage};
 use futures_util::{SinkExt, StreamExt};
-use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::broadcast;
-use tokio_tungstenite::tungstenite::Message;
 
 use crate::error::DaemonError;
+use crate::ingest::AppState;
 use crate::store::Store;
 
-pub async fn serve(
-    addr: SocketAddr,
-    store: Store,
-    fanout: broadcast::Sender<ServerMessage>,
-) -> Result<(), DaemonError> {
-    let listener = TcpListener::bind(addr).await?;
-    tracing::info!("ws fan-out bound to {addr}");
-
-    loop {
-        let (stream, peer) = match listener.accept().await {
-            Ok(p) => p,
-            Err(err) => {
-                tracing::warn!(%err, "ws accept failed");
-                continue;
-            }
-        };
-        let rx = fanout.subscribe();
-        let store = store.clone();
-        tokio::spawn(async move {
-            if let Err(err) = handle_connection(stream, store, rx).await {
-                tracing::debug!(%peer, %err, "ws connection closed");
-            }
-        });
-    }
+/// HTTP→WS upgrade handler mounted at `/ws/:project`. The project segment
+/// is reserved for future per-project filtering — today the snapshot is
+/// global and the SPA filters client-side, matching the previous server's
+/// behavior. Keeping the segment in the URL means SDKs and operators can
+/// already include it without a wire break later.
+pub async fn handle(
+    upgrade: WebSocketUpgrade,
+    Path(_project): Path<String>,
+    State(state): State<Arc<AppState>>,
+) -> Response {
+    let store = state.store.clone();
+    let rx = state.fanout.subscribe();
+    upgrade.on_upgrade(move |socket| async move {
+        if let Err(err) = run(socket, store, rx).await {
+            tracing::debug!(%err, "ws connection closed");
+        }
+    })
 }
 
-async fn handle_connection(
-    stream: TcpStream,
+async fn run(
+    socket: WebSocket,
     store: Store,
     mut fanout: broadcast::Receiver<ServerMessage>,
 ) -> Result<(), DaemonError> {
-    let ws = tokio_tungstenite::accept_async(stream)
-        .await
-        .map_err(|e| DaemonError::Io(std::io::Error::other(e)))?;
-    let (mut write, mut read) = ws.split();
+    let (mut write, mut read) = socket.split();
 
-    // Greet, then catch the client up. Subscribing to `fanout` happened
-    // before this snapshot was loaded, so any concurrent updates arrive
-    // after it — possibly re-stating an issue already in the snapshot,
-    // which the client handles idempotently by id.
+    // Subscribing happened before this snapshot loaded, so any concurrent
+    // updates arrive after — possibly re-stating an issue already in the
+    // snapshot, which the client handles idempotently by id.
     let issues = store.load_issues().await?;
     let hello = ServerMessage::Hello {
         server_version: env!("CARGO_PKG_VERSION").to_string(),
@@ -88,7 +86,7 @@ async fn handle_connection(
                 Err(broadcast::error::RecvError::Closed) => break,
             },
 
-            // Client-side traffic. We only honor pings today; richer commands
+            // Client-side traffic. Only honors pings today; richer commands
             // (resolve, mute) land here as the daemon grows.
             incoming = read.next() => match incoming {
                 Some(Ok(Message::Text(t))) => {

--- a/crates/errexd/tests/api.rs
+++ b/crates/errexd/tests/api.rs
@@ -45,6 +45,8 @@ mod spa;
 mod store;
 #[path = "../src/webhook.rs"]
 mod webhook;
+#[path = "../src/ws.rs"]
+mod ws;
 
 use ingest::AppState;
 use store::Store;
@@ -1513,6 +1515,104 @@ async fn admin_revoke_user_sessions_returns_count() {
     assert_eq!(res.status(), StatusCode::OK);
     let v = body_json(res).await;
     assert_eq!(v.get("sessions_revoked").and_then(|n| n.as_i64()), Some(3));
+}
+
+// ----- /ws/:project -----
+//
+// The fan-out WebSocket lives on the same listener as the HTTP API. These
+// tests bind a real ephemeral port (oneshot can't drive an upgrade) and
+// drive a tungstenite client against it. They pin the production-critical
+// invariant that brought us here: the daemon must answer the upgrade on
+// the HTTP port — the SPA builds its WS URL from `location.host`, so any
+// regression where /ws falls through to the SPA fallback (HTTP 200 +
+// index.html) breaks every browser instantly.
+
+use futures_util::{SinkExt, StreamExt};
+use std::net::SocketAddr;
+use tokio_tungstenite::tungstenite::Message;
+
+async fn spawn_server(router: axum::Router) -> SocketAddr {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let make = router.into_make_service_with_connect_info::<SocketAddr>();
+    tokio::spawn(async move {
+        axum::serve(listener, make).await.unwrap();
+    });
+    addr
+}
+
+async fn next_text(
+    ws: &mut tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+) -> serde_json::Value {
+    let msg = ws.next().await.expect("stream ended").expect("ws error");
+    match msg {
+        Message::Text(t) => serde_json::from_str(&t).expect("valid json"),
+        other => panic!("expected text frame, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn ws_handshake_returns_hello_then_snapshot() {
+    let (router, store, _dir) = fixture().await;
+    store
+        .upsert_issue(
+            "alpha",
+            &Fingerprint::new("a"),
+            "Boom",
+            None,
+            None,
+            Utc::now(),
+        )
+        .await
+        .unwrap();
+
+    let addr = spawn_server(router).await;
+    let url = format!("ws://{}/ws/alpha", addr);
+    let (mut ws, _resp) = tokio_tungstenite::connect_async(&url)
+        .await
+        .expect("upgrade");
+
+    let hello = next_text(&mut ws).await;
+    assert_eq!(hello.get("type").and_then(|s| s.as_str()), Some("hello"));
+    assert!(hello.get("server_version").is_some());
+
+    let snap = next_text(&mut ws).await;
+    assert_eq!(snap.get("type").and_then(|s| s.as_str()), Some("snapshot"));
+    let issues = snap
+        .get("issues")
+        .and_then(|i| i.as_array())
+        .expect("snapshot issues array");
+    assert_eq!(issues.len(), 1);
+    assert_eq!(
+        issues[0].get("project").and_then(|s| s.as_str()),
+        Some("alpha")
+    );
+}
+
+#[tokio::test]
+async fn ws_ping_keepalive_does_not_close() {
+    // Client-side Ping is documented as a no-op heartbeat. If the daemon
+    // ever started replying with Close on unknown messages, the keepalive
+    // would tear sockets down — pin it.
+    let (router, _store, _dir) = fixture().await;
+    let addr = spawn_server(router).await;
+    let url = format!("ws://{}/ws/alpha", addr);
+    let (mut ws, _) = tokio_tungstenite::connect_async(&url).await.unwrap();
+
+    let _hello = next_text(&mut ws).await;
+    let _snap = next_text(&mut ws).await;
+
+    ws.send(Message::Text(r#"{"type":"ping"}"#.into()))
+        .await
+        .unwrap();
+
+    // Round-trip a ws-level ping/pong to prove the connection is still
+    // alive without racing on absence-of-message.
+    ws.send(Message::Ping(vec![])).await.unwrap();
+    let pong = ws.next().await.expect("pong").expect("ws ok");
+    assert!(matches!(pong, Message::Pong(_)), "got {:?}", pong);
 }
 
 // ----- /health -----

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,8 +7,8 @@ services:
     container_name: errexd
     restart: unless-stopped
     ports:
+      # 9090 = HTTP + WS (axum upgrade); 9092 = MCP stub.
       - "9090:9090"
-      - "9091:9091"
       - "9092:9092"
     volumes:
       # Named volume so /data inherits the image's UID 1000 ownership.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,9 +17,13 @@ SDK ──HTTP─▶  /api/<proj>/envelope/  ─▶  │  digest task       │
                                             │          │
                               ┌─────────────┴──┐  ┌────┴───────┐
                               ▼                ▼  ▼            ▼
-                     /api/issues, /event   webhook task    WebSocket fan-out
-                     (REST, embedded SPA)   (POST out)     :9091 → SPA
+                     /api/issues, /event   webhook task    /ws/<proj> upgrade
+                     (REST, embedded SPA)   (POST out)     (axum, same :9090)
 ```
+
+Both REST and the WebSocket fan-out share the axum listener on `:9090`
+— the SPA's WS URL is built from `location.host`, so unifying the ports
+keeps the upgrade reachable in production without env-time configuration.
 
 Three things move through this pipeline:
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -11,8 +11,7 @@ self-host.
 | Variable | Default | What it does |
 |---|---|---|
 | `ERREXD_DATA_DIR` | `./data` | SQLite file location |
-| `ERREXD_HTTP_PORT` | `9090` | HTTP + SPA port |
-| `ERREXD_WS_PORT` | `9091` | WebSocket fan-out port |
+| `ERREXD_HTTP_PORT` | `9090` | HTTP + SPA + WebSocket fan-out (single axum listener) |
 | `ERREXD_MCP_PORT` | `9092` | MCP listener (stub) |
 | `ERREXD_LOG_LEVEL` | `info` | tracing filter |
 | `ERREXD_DEV_MODE` | `false` | Enable CORS for the Vite dev server |
@@ -25,16 +24,16 @@ self-host.
 
 ### Ports
 
-errex listens on three ports by default:
+errex listens on two ports by default:
 
-- `9090` — HTTP (Sentry ingest, REST API, embedded SPA)
-- `9091` — WebSocket fan-out (live updates for the dashboard)
+- `9090` — HTTP (Sentry ingest, REST API, embedded SPA, WebSocket upgrade)
 - `9092` — MCP listener (stub for AI agents)
 
-If you put errex behind a reverse proxy, route `/api`, `/ws`, and the SPA
-root to `9090`/`9091` accordingly. The SPA looks for the WebSocket at the
-same origin under `/ws`, so a typical nginx config proxies `/ws` to `9091`
-and everything else to `9090`.
+If you put errex behind a reverse proxy, forward everything to `9090` —
+the SPA, REST API, and WebSocket fan-out all share that listener. The SPA
+builds its WS URL from `location.host`, so anything that already proxies
+HTTP correctly will handle `/ws/<project>` upgrades without extra config
+(make sure the proxy passes through `Upgrade`/`Connection` headers).
 
 ## First-run setup
 

--- a/errex.sh
+++ b/errex.sh
@@ -87,7 +87,7 @@ cmd_shell() {
 # running daemon. host.docker.internal works on Docker Desktop (macOS/Win);
 # override ERREX_DAEMON_URL on Linux if needed.
 cmd_tui() {
-  local daemon_url="${ERREX_DAEMON_URL:-ws://host.docker.internal:9091}"
+  local daemon_url="${ERREX_DAEMON_URL:-ws://host.docker.internal:9090}"
   docker run --rm -it \
     -v "$ROOT:/work" \
     -v errex-cargo-registry:/usr/local/cargo/registry \

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # Run errexd + the SvelteKit dev server in parallel for local iteration.
 #
-#   - errexd binds :9090 (HTTP), :9091 (WS), :9092 (MCP stub) and runs with
-#     ERREXD_DEV_MODE=true so its CORS policy permits direct fetches from
-#     the Vite dev server on :5173.
+#   - errexd binds :9090 (HTTP+WS, same axum listener) and :9092 (MCP stub)
+#     and runs with ERREXD_DEV_MODE=true so its CORS policy permits direct
+#     fetches from the Vite dev server on :5173.
 #   - bun run dev binds :5173 with /api and /ws proxied to the daemon.
 #
 # Ctrl-C tears both processes down via a trap on EXIT.
@@ -25,7 +25,7 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-echo "[dev] starting errexd on :9090/:9091 (dev mode)"
+echo "[dev] starting errexd on :9090 (HTTP+WS, dev mode)"
 ERREXD_DEV_MODE=true \
 ERREXD_LOG_LEVEL="${ERREXD_LOG_LEVEL:-info}" \
 ERREXD_ADMIN_TOKEN="${ERREXD_ADMIN_TOKEN:-123}" \

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -13,7 +13,6 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BIN="$ROOT/target/release/errexd"
 DATA="$(mktemp -d)"
 PORT=19090
-WS_PORT=19091
 MCP_PORT=19092
 
 if [[ ! -x "$BIN" ]]; then
@@ -33,7 +32,6 @@ trap cleanup EXIT INT TERM
 
 ERREXD_DATA_DIR="$DATA" \
 ERREXD_HTTP_PORT="$PORT" \
-ERREXD_WS_PORT="$WS_PORT" \
 ERREXD_MCP_PORT="$MCP_PORT" \
 ERREXD_LOG_LEVEL=warn \
   "$BIN" &

--- a/web/src/lib/ws.test.ts
+++ b/web/src/lib/ws.test.ts
@@ -1,0 +1,102 @@
+// Lifecycle of the singleton WebSocket. The bug it pins: connect(X) followed
+// by connect(X) used to tear down the in-flight socket and open a new one,
+// producing the browser warning "WebSocket is closed before the connection
+// is established" and wasting the handshake. After the fix, same-project
+// re-calls are no-ops; cross-project still tears down and reopens.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+class MockWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+  url: string;
+  readyState: number = MockWebSocket.CONNECTING;
+  onopen: ((ev: Event) => void) | null = null;
+  onclose: ((ev: CloseEvent) => void) | null = null;
+  onerror: ((ev: Event) => void) | null = null;
+  onmessage: ((ev: MessageEvent) => void) | null = null;
+  closed = false;
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+  close() {
+    this.closed = true;
+    if (
+      this.readyState === MockWebSocket.CONNECTING ||
+      this.readyState === MockWebSocket.OPEN
+    ) {
+      this.readyState = MockWebSocket.CLOSED;
+      this.onclose?.({} as CloseEvent);
+    }
+  }
+}
+
+beforeEach(() => {
+  MockWebSocket.instances = [];
+  vi.stubGlobal('WebSocket', MockWebSocket);
+  // Module-level state in ws.ts (socket, pendingProject, reconnectTimer)
+  // must reset between tests, so we re-import per case.
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+async function loadWs() {
+  const stores = await import('./stores.svelte');
+  stores.projects.current = 'default';
+  const ws = await import('./ws');
+  return ws;
+}
+
+describe('ws.connect', () => {
+  it('opens a single WebSocket on first call', async () => {
+    const { connect } = await loadWs();
+    connect('foo');
+    expect(MockWebSocket.instances).toHaveLength(1);
+    expect(MockWebSocket.instances[0].url).toMatch(/\/ws\/foo$/);
+    expect(MockWebSocket.instances[0].closed).toBe(false);
+  });
+
+  it('is a no-op when called again with the same project while CONNECTING', async () => {
+    const { connect } = await loadWs();
+    connect('foo');
+    connect('foo');
+    expect(MockWebSocket.instances).toHaveLength(1);
+    expect(MockWebSocket.instances[0].closed).toBe(false);
+  });
+
+  it('is a no-op when called again with the same project while OPEN', async () => {
+    const { connect } = await loadWs();
+    connect('foo');
+    MockWebSocket.instances[0].readyState = MockWebSocket.OPEN;
+    connect('foo');
+    expect(MockWebSocket.instances).toHaveLength(1);
+    expect(MockWebSocket.instances[0].closed).toBe(false);
+  });
+
+  it('tears down the existing socket and opens a new one when switching projects', async () => {
+    const { connect } = await loadWs();
+    connect('foo');
+    connect('bar');
+    expect(MockWebSocket.instances).toHaveLength(2);
+    expect(MockWebSocket.instances[0].closed).toBe(true);
+    expect(MockWebSocket.instances[1].url).toMatch(/\/ws\/bar$/);
+    expect(MockWebSocket.instances[1].closed).toBe(false);
+  });
+
+  it('reopens after disconnect()', async () => {
+    const { connect, disconnect } = await loadWs();
+    connect('foo');
+    disconnect();
+    expect(MockWebSocket.instances[0].closed).toBe(true);
+    connect('foo');
+    expect(MockWebSocket.instances).toHaveLength(2);
+    expect(MockWebSocket.instances[1].closed).toBe(false);
+  });
+});

--- a/web/src/lib/ws.test.ts
+++ b/web/src/lib/ws.test.ts
@@ -54,13 +54,23 @@ async function loadWs() {
   return ws;
 }
 
+// Small accessor so each test reads a concrete `MockWebSocket` instead of
+// `MockWebSocket | undefined`. TS strict (`noUncheckedIndexedAccess`)
+// would otherwise force `?.` at every callsite, which obscures the
+// invariant the assertions are about to prove.
+function inst(n: number): MockWebSocket {
+  const ws = MockWebSocket.instances[n];
+  if (!ws) throw new Error(`no MockWebSocket instance at index ${n}`);
+  return ws;
+}
+
 describe('ws.connect', () => {
   it('opens a single WebSocket on first call', async () => {
     const { connect } = await loadWs();
     connect('foo');
     expect(MockWebSocket.instances).toHaveLength(1);
-    expect(MockWebSocket.instances[0].url).toMatch(/\/ws\/foo$/);
-    expect(MockWebSocket.instances[0].closed).toBe(false);
+    expect(inst(0).url).toMatch(/\/ws\/foo$/);
+    expect(inst(0).closed).toBe(false);
   });
 
   it('is a no-op when called again with the same project while CONNECTING', async () => {
@@ -68,16 +78,16 @@ describe('ws.connect', () => {
     connect('foo');
     connect('foo');
     expect(MockWebSocket.instances).toHaveLength(1);
-    expect(MockWebSocket.instances[0].closed).toBe(false);
+    expect(inst(0).closed).toBe(false);
   });
 
   it('is a no-op when called again with the same project while OPEN', async () => {
     const { connect } = await loadWs();
     connect('foo');
-    MockWebSocket.instances[0].readyState = MockWebSocket.OPEN;
+    inst(0).readyState = MockWebSocket.OPEN;
     connect('foo');
     expect(MockWebSocket.instances).toHaveLength(1);
-    expect(MockWebSocket.instances[0].closed).toBe(false);
+    expect(inst(0).closed).toBe(false);
   });
 
   it('tears down the existing socket and opens a new one when switching projects', async () => {
@@ -85,18 +95,18 @@ describe('ws.connect', () => {
     connect('foo');
     connect('bar');
     expect(MockWebSocket.instances).toHaveLength(2);
-    expect(MockWebSocket.instances[0].closed).toBe(true);
-    expect(MockWebSocket.instances[1].url).toMatch(/\/ws\/bar$/);
-    expect(MockWebSocket.instances[1].closed).toBe(false);
+    expect(inst(0).closed).toBe(true);
+    expect(inst(1).url).toMatch(/\/ws\/bar$/);
+    expect(inst(1).closed).toBe(false);
   });
 
   it('reopens after disconnect()', async () => {
     const { connect, disconnect } = await loadWs();
     connect('foo');
     disconnect();
-    expect(MockWebSocket.instances[0].closed).toBe(true);
+    expect(inst(0).closed).toBe(true);
     connect('foo');
     expect(MockWebSocket.instances).toHaveLength(2);
-    expect(MockWebSocket.instances[1].closed).toBe(false);
+    expect(inst(1).closed).toBe(false);
   });
 });

--- a/web/src/lib/ws.ts
+++ b/web/src/lib/ws.ts
@@ -16,9 +16,10 @@ let pendingProject: string | null = null;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
 function url(project: string): string {
-  // In production the SPA is same-origin with the daemon; the WS server lives
-  // on a different port. Vite's proxy rewrites /ws/<project> → ws://host:9091
-  // in dev, so the path is identical in both environments.
+  // Same origin as the SPA in both prod and dev. In prod the daemon's axum
+  // listener handles the upgrade on the HTTP port; in dev Vite proxies
+  // /ws/* to that same listener. Building from `location.host` keeps the
+  // SPA portable across deployments without env-time configuration.
   if (!browser) return '';
   const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
   return `${proto}//${location.host}/ws/${encodeURIComponent(project)}`;
@@ -26,6 +27,21 @@ function url(project: string): string {
 
 export function connect(project: string) {
   if (!browser) return;
+  // Idempotent for same-project re-calls: if we're already connecting or
+  // connected to this project, leave the socket alone. Without this guard,
+  // two callers in the same tick (bootstrap + page-effect on a project
+  // route, an HMR re-fire, etc.) would close an in-flight socket and trip
+  // the browser's "WebSocket is closed before the connection is
+  // established" warning.
+  if (
+    socket &&
+    pendingProject === project &&
+    (socket.readyState === WebSocket.CONNECTING || socket.readyState === WebSocket.OPEN)
+  ) {
+    projects.current = project;
+    return;
+  }
+
   // Project switch invalidates the in-memory view; the new project will
   // arrive via Snapshot in a moment.
   if (project !== projects.current) eventStream.clear();

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -6,6 +6,10 @@ import { defineConfig } from 'vite';
 // behaves the same as it does in prod (where it's served from the daemon
 // itself). The daemon must be started with ERREXD_DEV_MODE=true so its CORS
 // policy permits direct fetches that bypass this proxy.
+//
+// Both /api and /ws live on the same daemon listener (axum handles the
+// upgrade), so the WS proxy doesn't rewrite the path — `/ws/<project>`
+// reaches the daemon as-is.
 export default defineConfig({
   plugins: [tailwindcss(), sveltekit()],
   server: {
@@ -14,10 +18,9 @@ export default defineConfig({
     proxy: {
       '/api': { target: 'http://localhost:9090', changeOrigin: true },
       '/ws': {
-        target: 'ws://localhost:9091',
+        target: 'ws://localhost:9090',
         ws: true,
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/ws/, '')
+        changeOrigin: true
       }
     }
   }


### PR DESCRIPTION
## Summary
- **Production bug**: SPA built its WS URL from `location.host` (the HTTP port :9090), but the fan-out listened on :9091. The upgrade fell through to the SPA fallback and got `200 + index.html` instead of `101`, breaking every browser. Fixed by mounting `/ws/:project` on the axum HTTP listener via `WebSocketUpgrade` and dropping the dedicated :9091 server.
- **Dev-mode warning**: bootstrap (in layout) and the route effect (in `/projects/[name]`) raced, re-entering `connect()` twice in the same tick and tripping the browser's "WebSocket is closed before the connection is established" warning. Fixed by making `connect()` idempotent for same-project re-calls.
- **Footprint**: one fewer TCP listener, one fewer port to expose in `docker-compose.yml`. Aligns with the self-host-pequeno constraint.

## Test plan
- [x] `./errex.sh check` (rust gate: fmt + clippy `-D warnings` + workspace tests) → 323 passed
- [x] `cd web && bun run test` → 13 files / 123 passed
- [x] New `tests/api.rs::ws_handshake_returns_hello_then_snapshot` was RED before the route move (got HTML body via SPA fallback) and is GREEN after
- [x] New `tests/api.rs::ws_ping_keepalive_does_not_close` exercises the client→server path on the unified listener
- [x] New `web/src/lib/ws.test.ts` (5 cases) pins idempotency: open / no-op while CONNECTING / no-op while OPEN / tear-down on project switch / reopen after disconnect
- [ ] Live verify after restart: bring up the rebuilt daemon and confirm browser console no longer shows the warning on `/projects/<name>` first paint
- [ ] Live verify in prod-shape: `docker compose up`, open `http://localhost:9090`, confirm WS connects without :9091 exposed

## Notes for reviewer
- `ERREXD_WS_PORT` / `ERREXD_WS_HOST` are removed (clean break). Anyone overriding them in deployment manifests needs to drop the var.
- `docker/docker-compose.yml` no longer publishes :9091.
- The `:project` segment in `/ws/:project` is parsed but not yet used server-side — kept in the URL so the wire stays compatible when per-project filtering lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)