### PR TITLE
fix(ingest): bump last_used_at on every envelope, not just authed

### DIFF
--- a/crates/errexd/src/ingest.rs
+++ b/crates/errexd/src/ingest.rs
@@ -747,9 +747,7 @@ async fn ingest_envelope(
             return (StatusCode::UNAUTHORIZED, "missing sentry_key").into_response();
         };
         match state.store.project_by_token(&key).await {
-            Ok(Some(p)) if p.name == project => {
-                state.store.touch_project_used(&p.name).await;
-            }
+            Ok(Some(p)) if p.name == project => {}
             Ok(_) => {
                 return (StatusCode::UNAUTHORIZED, "invalid sentry_key for project")
                     .into_response();
@@ -784,6 +782,12 @@ async fn ingest_envelope(
             return (StatusCode::BAD_REQUEST, "invalid envelope").into_response();
         }
     };
+
+    // Telemetry: bump `last_used_at` for any successfully-parsed envelope,
+    // including session-only envelopes. The SPA reads this for the project
+    // header's "last event" line, so it must reflect SDK liveness regardless
+    // of whether ingest auth is enabled.
+    state.store.touch_project_used(&project).await;
 
     if events.is_empty() {
         // Sentry SDKs send envelopes that contain only sessions or

--- a/crates/errexd/src/ingest.rs
+++ b/crates/errexd/src/ingest.rs
@@ -783,15 +783,11 @@ async fn ingest_envelope(
         }
     };
 
-    // Telemetry: bump `last_used_at` for any successfully-parsed envelope,
-    // including session-only envelopes. The SPA reads this for the project
-    // header's "last event" line, so it must reflect SDK liveness regardless
-    // of whether ingest auth is enabled.
-    state.store.touch_project_used(&project).await;
-
     if events.is_empty() {
         // Sentry SDKs send envelopes that contain only sessions or
         // transactions; that's not an error, just nothing for us yet.
+        // Still bump telemetry — SDK is alive even if it sent no events.
+        state.store.touch_project_used(&project).await;
         return StatusCode::OK.into_response();
     }
 
@@ -805,10 +801,16 @@ async fn ingest_envelope(
             .await
             .is_err()
         {
+            // Digest receiver gone = shutting down. Don't bump telemetry
+            // for a request we didn't actually accept.
             return (StatusCode::SERVICE_UNAVAILABLE, "shutting down").into_response();
         }
     }
 
+    // Telemetry: SPA's project header reads `last_used_at` for the "last
+    // event" line, so it must reflect SDK liveness regardless of whether
+    // ingest auth is enabled. Bump only after the envelope was accepted.
+    state.store.touch_project_used(&project).await;
     StatusCode::OK.into_response()
 }
 

--- a/crates/errexd/src/store.rs
+++ b/crates/errexd/src/store.rs
@@ -461,9 +461,9 @@ impl Store {
 
     /// Bumps `last_used_at` for telemetry. Best-effort — a missing row or
     /// transient SQLite contention is logged and swallowed.
-    /// Used by ingest auth path; tests/store.rs doesn't exercise it
-    /// directly (covered via the api.rs auth tests instead).
-    #[allow(dead_code)]
+    /// Called on every successful envelope ingest; tests/store.rs doesn't
+    /// exercise it directly (covered via the api.rs ingest tests instead).
+    #[allow(dead_code)] // reason: tests/store.rs binary doesn't call this; api.rs binary does
     pub async fn touch_project_used(&self, name: &str) {
         if let Err(err) = sqlx::query("UPDATE projects SET last_used_at = ? WHERE name = ?")
             .bind(Utc::now().to_rfc3339())

--- a/crates/errexd/tests/api.rs
+++ b/crates/errexd/tests/api.rs
@@ -298,7 +298,10 @@ async fn ingest_without_auth_bumps_project_last_used_at() {
     // It must update on every successful ingest, not just when auth is on.
     let (router, store, _dir) = fixture_with_auth(false).await;
     let p = store.create_project("p").await.unwrap();
-    assert!(p.last_used_at.is_none(), "fresh project starts with no last_used_at");
+    assert!(
+        p.last_used_at.is_none(),
+        "fresh project starts with no last_used_at"
+    );
 
     let res = router
         .oneshot(

--- a/crates/errexd/tests/api.rs
+++ b/crates/errexd/tests/api.rs
@@ -293,6 +293,33 @@ async fn ingest_without_auth_required_accepts_anonymous_post() {
 }
 
 #[tokio::test]
+async fn ingest_without_auth_bumps_project_last_used_at() {
+    // Telemetry: `last_used_at` powers the "no events yet" header in the SPA.
+    // It must update on every successful ingest, not just when auth is on.
+    let (router, store, _dir) = fixture_with_auth(false).await;
+    let p = store.create_project("p").await.unwrap();
+    assert!(p.last_used_at.is_none(), "fresh project starts with no last_used_at");
+
+    let res = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/p/envelope/")
+                .body(sample_envelope_body())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let after = store.project_by_name("p").await.unwrap().unwrap();
+    assert!(
+        after.last_used_at.is_some(),
+        "successful ingest must bump last_used_at even when require_auth is false",
+    );
+}
+
+#[tokio::test]
 async fn ingest_with_auth_required_rejects_missing_token() {
     let (router, store, _dir) = fixture_with_auth(true).await;
     let _ = store.create_project("p").await.unwrap();

--- a/crates/errexd/tests/api.rs
+++ b/crates/errexd/tests/api.rs
@@ -52,10 +52,18 @@ use ingest::AppState;
 use store::Store;
 
 fn unique_tempdir() -> PathBuf {
+    // Atomic counter prevents same-nanosecond collisions across the ~140
+    // tests running in parallel in this binary. Two colliding paths would
+    // share a SQLite file and cause `UNIQUE constraint failed:
+    // _sqlx_migrations.version` on the second migrate.
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
     let p = std::env::temp_dir().join(format!(
-        "errexd-api-{}-{}",
+        "errexd-api-{}-{}-{}",
         std::process::id(),
-        Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        Utc::now().timestamp_nanos_opt().unwrap_or_default(),
+        seq,
     ));
     let _ = std::fs::remove_dir_all(&p);
     std::fs::create_dir_all(&p).expect("create tempdir");

--- a/crates/errexd/tests/store.rs
+++ b/crates/errexd/tests/store.rs
@@ -33,11 +33,17 @@ use store::{Role, Store};
 // ----- helpers -----
 
 fn unique_tempdir() -> PathBuf {
-    // PID + nanos so parallel cargo test workers don't collide.
+    // PID + nanos + atomic seq so parallel cargo test workers don't
+    // collide. Same-nanosecond starts (likely under heavy parallelism)
+    // would otherwise share a SQLite file and re-run migrations.
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
     let p = std::env::temp_dir().join(format!(
-        "errexd-store-{}-{}",
+        "errexd-store-{}-{}-{}",
         std::process::id(),
-        Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        Utc::now().timestamp_nanos_opt().unwrap_or_default(),
+        seq,
     ));
     let _ = std::fs::remove_dir_all(&p);
     std::fs::create_dir_all(&p).expect("create tempdir");


### PR DESCRIPTION
## Summary
- `touch_project_used` was only called inside the `if state.require_auth` branch in `ingest_envelope`, so when `ERREXD_REQUIRE_AUTH=false` (default) the column never updated.
- The SPA project header reads `project.last_used_at` for "no events yet" vs. "last event Xs ago", while the activity counters read directly from the events table — producing the mismatch (`3 events 24h` next to `no events yet`) when auth is off.
- Move the touch out of the auth branch and fire it once `parse_envelope` succeeds, covering session-only envelopes too.

## Test plan
- [x] New `ingest_without_auth_bumps_project_last_used_at` test in `crates/errexd/tests/api.rs` — red before fix, green after.
- [x] Existing 5 `ingest_with_auth_required_*` tests still pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [ ] Manually verify in the SPA: post a test event with auth off, confirm header flips from "no events yet" to "last event Xs ago".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Project usage timestamps now update when an envelope is accepted for processing (including anonymous/unauthenticated ingestion). Timestamps are intentionally not updated when the request cannot be accepted (service unavailable).

* **Tests**
  * Added an integration test verifying project usage timestamp updates during unauthenticated envelope ingestion.
  * Hardened test temp-directory naming to avoid rare collisions under heavy parallelism.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->