### PR TITLE
web: enforce shadcn primitives in feature components

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,8 +152,25 @@ Do **not** open a PR or mark a task done if step 1 was skipped.
   `$effect`. No `export let`, no stores from `svelte/store`.
 - TypeScript strict; no `any`. Extend wire types in `lib/types.ts` to
   match `errex-proto` field-for-field.
-- Components compose shadcn-style primitives in `lib/components/ui/`;
-  feature components in `lib/components/`.
+- **shadcn primitives are the only UI vocabulary.** Feature components
+  in `lib/components/` and routes in `src/routes/` MUST compose the
+  primitives in `lib/components/ui/` (currently: avatar, badge, button,
+  card, checkbox, collapsible, dialog, input, label, popover, resizable,
+  select, separator, skeleton, tooltip). Specifically forbidden in
+  feature/route code:
+  - Raw `<button>` — use `Button` (variant=`ghost size=icon` for icon
+    buttons, `link` for inline text actions).
+  - Raw `<input>`, `<select>`, `<dialog>`, `<label>` — use the
+    corresponding primitive.
+  - DIY chrome that recreates a primitive's look (e.g.,
+    `rounded-full px-2 py-0.5 text-xs` for a badge, `rounded-md border
+    bg-card` for a card, `animate-pulse bg-muted` for a skeleton,
+    custom hover popovers).
+  - **Escape hatch:** if no primitive fits (kbd shortcut, code block,
+    flame graph, etc.), add a new primitive to `lib/components/ui/`
+    FIRST in the same PR, then consume it. Do not improvise inline.
+  - Pure layout elements (`div`, `section`, `nav`, `ul`, `table`, etc.)
+    and SVG/icon usage are not primitives and remain raw HTML.
 - Never reach for an in-memory cache in the frontend either — the WS
   socket plus REST is enough; bounded ring buffers if you need windowed
   state (see `eventStream.svelte.ts`).
@@ -171,6 +188,9 @@ Do **not** open a PR or mark a task done if step 1 was skipped.
   modules without also adding tests for them (per TDD rule above).
 - Don't add visual snapshot tests for components — they rot fast and
   catch nothing real at this size.
+- Don't bypass the shadcn primitive layer in feature components or
+  routes. If a primitive is missing, extend `lib/components/ui/`
+  instead of inlining the markup (see "Style — frontend").
 
 ## Quick references
 

--- a/web/src/lib/components/CommandPalette.svelte
+++ b/web/src/lib/components/CommandPalette.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { Search } from 'lucide-svelte';
   import { goto } from '$app/navigation';
+  import { Button } from '$lib/components/ui/button';
   import { Dialog } from '$lib/components/ui/dialog';
   import { actions } from '$lib/actions.svelte';
   import { toggleMute, toggleResolve } from '$lib/issueOps';
@@ -198,12 +199,13 @@
     {:else}
       {#each commands as cmd, i (cmd.id)}
         <li>
-          <button
-            type="button"
+          <Button
+            variant="ghost"
+            size="sm"
             onmouseenter={() => (cursor = i)}
             onclick={() => cmd.run()}
             class={cn(
-              'flex w-full items-center gap-3 px-4 py-2.5 text-left text-[13px]',
+              'h-auto w-full justify-start gap-3 rounded-none px-4 py-2.5 text-left text-[13px] font-normal',
               i === cursor ? 'bg-accent text-accent-foreground' : 'text-foreground'
             )}
           >
@@ -216,7 +218,7 @@
             {#if cmd.hint}
               <span class="text-muted-foreground shrink-0 font-mono text-[11px]">{cmd.hint}</span>
             {/if}
-          </button>
+          </Button>
         </li>
       {/each}
     {/if}

--- a/web/src/lib/components/IssueList.svelte
+++ b/web/src/lib/components/IssueList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Ban, BellOff, Check, Circle, Search, ShieldCheck } from 'lucide-svelte';
+  import { Button } from '$lib/components/ui/button';
   import { Input } from '$lib/components/ui/input';
   import { Skeleton } from '$lib/components/ui/skeleton';
   import * as Tooltip from '$lib/components/ui/tooltip';
@@ -77,19 +78,22 @@
         <Tooltip.Root>
           <Tooltip.Trigger>
             {#snippet child({ props })}
-              <button
+              <Button
                 {...props}
-                type="button"
+                variant="outline"
+                size="icon"
                 onclick={() => filter.toggleStatus(chip.key)}
                 aria-pressed={on}
                 aria-label={chip.label}
                 class={cn(
-                  'border-border inline-flex h-9 w-9 items-center justify-center rounded-md border transition-colors',
-                  on ? 'bg-accent text-foreground' : 'text-muted-foreground/60 hover:text-foreground hover:bg-accent/50'
+                  'h-9 w-9',
+                  on
+                    ? 'bg-accent text-foreground'
+                    : 'text-muted-foreground/60 hover:text-foreground hover:bg-accent/50'
                 )}
               >
                 <chip.Icon class="h-4 w-4" />
-              </button>
+              </Button>
             {/snippet}
           </Tooltip.Trigger>
           <Tooltip.Content>{chip.label} ({statusCount(chip.key)})</Tooltip.Content>
@@ -118,16 +122,17 @@
     {:else if visible.length === 0 && hasActiveFilter}
       <div class="text-muted-foreground flex flex-col items-center gap-2 p-8 text-center text-[12px]">
         <p>No issues match this filter.</p>
-        <button
-          type="button"
+        <Button
+          variant="link"
+          size="sm"
           onclick={() => {
             filter.query = '';
             filter.statuses = new Set<IssueStatus>(['unresolved']);
           }}
-          class="text-primary hover:underline text-[12px]"
+          class="h-auto p-0 text-[12px]"
         >
           Clear filters
-        </button>
+        </Button>
       </div>
     {:else if visible.length === 0}
       <div

--- a/web/src/lib/components/IssueRow.svelte
+++ b/web/src/lib/components/IssueRow.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import { Ban, BellOff, Check, Flame } from 'lucide-svelte';
   import { actions } from '$lib/actions.svelte';
-  import { Badge } from '$lib/components/ui/badge';
   import * as Avatar from '$lib/components/ui/avatar';
+  import { Badge } from '$lib/components/ui/badge';
+  import { Button } from '$lib/components/ui/button';
   import * as Tooltip from '$lib/components/ui/tooltip';
   import { eventStream } from '$lib/eventStream.svelte';
   import type { Issue } from '$lib/types';
@@ -65,12 +66,12 @@
   const initial = $derived(assignee ? assignee[0]!.toUpperCase() : '');
 </script>
 
-<button
-  type="button"
+<Button
+  variant="ghost"
   onclick={() => onSelect?.(issue.id)}
   class={cn(
-    'relative flex min-h-[60px] w-full items-center gap-4 px-5 py-3 text-left transition-colors',
-    'hover:bg-accent border-b border-border/50',
+    'relative flex h-auto min-h-[60px] w-full justify-start gap-4 whitespace-normal rounded-none px-5 py-3 text-left text-[14px] font-normal',
+    'border-b border-border/50',
     "before:absolute before:inset-y-0 before:left-0 before:w-0.5 before:content-['']",
     railClass,
     selected && 'bg-accent/70',
@@ -155,4 +156,4 @@
   <span class="shrink-0 text-[12px] text-muted-foreground tabular-nums">
     {relativeTime(issue.last_seen)}
   </span>
-</button>
+</Button>

--- a/web/src/lib/components/ProjectDetail.svelte
+++ b/web/src/lib/components/ProjectDetail.svelte
@@ -354,14 +354,15 @@
         Connection · DSN
       </Label>
       <DsnSnippet dsn={project.dsn} label={`DSN for ${project.name}`} />
-      <button
-        type="button"
+      <Button
+        variant="ghost"
+        size="sm"
         onclick={copyCurl}
-        class="text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 self-start text-[11px] transition-colors"
+        class="text-muted-foreground hover:text-foreground hover:bg-transparent h-auto self-start p-0 text-[11px] font-normal"
       >
         <ClipboardCopy class="h-3 w-3" />
         Copy a curl that sends a test event
-      </button>
+      </Button>
     </section>
 
     <Separator />

--- a/web/src/lib/components/ProjectSelector.svelte
+++ b/web/src/lib/components/ProjectSelector.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { ChevronsUpDown, FolderKanban } from 'lucide-svelte';
+  import { Button } from '$lib/components/ui/button';
   import * as Popover from '$lib/components/ui/popover';
   import * as Tooltip from '$lib/components/ui/tooltip';
   import { cn } from '$lib/utils';
@@ -31,28 +32,30 @@
         <Tooltip.Root>
           <Tooltip.Trigger>
             {#snippet child({ props: tooltipProps })}
-              <button
+              <Button
                 {...props}
                 {...tooltipProps}
-                type="button"
-                class="text-muted-foreground hover:text-foreground hover:bg-accent inline-flex h-10 w-10 items-center justify-center rounded-md transition-colors data-[state=open]:bg-accent data-[state=open]:text-foreground"
+                variant="ghost"
+                size="icon"
+                class="text-muted-foreground hover:text-foreground h-10 w-10 data-[state=open]:bg-accent data-[state=open]:text-foreground"
                 aria-label="Switch project"
               >
                 <FolderKanban class="h-[18px] w-[18px]" />
-              </button>
+              </Button>
             {/snippet}
           </Tooltip.Trigger>
           <Tooltip.Content side="right">Project: {projects.current}</Tooltip.Content>
         </Tooltip.Root>
       {:else}
-        <button
+        <Button
           {...props}
-          type="button"
-          class="text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 text-[12px] tracking-tight transition-colors"
+          variant="ghost"
+          size="sm"
+          class="text-muted-foreground hover:text-foreground hover:bg-transparent h-auto gap-1.5 p-0 text-[12px] font-normal tracking-tight"
         >
           {projects.current}
           <ChevronsUpDown class="h-3.5 w-3.5" />
-        </button>
+        </Button>
       {/if}
     {/snippet}
   </Popover.Trigger>
@@ -60,11 +63,12 @@
     <ul class="flex flex-col">
       {#each items as item (item.value)}
         <li>
-          <button
-            type="button"
+          <Button
+            variant="ghost"
+            size="sm"
             onclick={() => pick(item.value)}
             class={cn(
-              'hover:bg-accent flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-[12px]',
+              'h-auto w-full justify-between rounded-sm px-2 py-1.5 text-[12px] font-normal',
               item.value === projects.current && 'bg-accent/60 font-medium'
             )}
           >
@@ -72,7 +76,7 @@
             {#if item.count != null}
               <span class="text-muted-foreground tabular-nums text-[10px]">{item.count}</span>
             {/if}
-          </button>
+          </Button>
         </li>
       {/each}
     </ul>

--- a/web/src/lib/components/Toaster.svelte
+++ b/web/src/lib/components/Toaster.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { X } from 'lucide-svelte';
+  import { Button } from '$lib/components/ui/button';
   import { toast } from '$lib/toast.svelte';
   import { cn } from '$lib/utils';
 
@@ -38,25 +39,27 @@
         {/if}
       </div>
       {#if t.undo}
-        <button
-          type="button"
+        <Button
+          variant="link"
+          size="sm"
           onclick={() => {
             t.undo?.();
             toast.dismiss(t.id);
           }}
-          class="text-primary hover:underline shrink-0 font-medium"
+          class="h-auto shrink-0 p-0 font-medium"
         >
           Undo
-        </button>
+        </Button>
       {/if}
-      <button
-        type="button"
+      <Button
+        variant="ghost"
+        size="icon"
         aria-label="Close"
         onclick={() => toast.dismiss(t.id)}
-        class="text-muted-foreground hover:text-foreground shrink-0"
+        class="text-muted-foreground hover:text-foreground h-5 w-5 shrink-0"
       >
         <X class="h-3 w-3" />
-      </button>
+      </Button>
     </div>
   {/each}
 </div>

--- a/web/src/lib/components/UserDetail.svelte
+++ b/web/src/lib/components/UserDetail.svelte
@@ -10,6 +10,7 @@
   } from 'lucide-svelte';
   import { goto } from '$app/navigation';
   import { auth } from '$lib/auth.svelte';
+  import { Badge } from '$lib/components/ui/badge';
   import { Button } from '$lib/components/ui/button';
   import { Dialog } from '$lib/components/ui/dialog';
   import { Input } from '$lib/components/ui/input';
@@ -170,20 +171,19 @@
       <div class="flex items-center gap-2">
         <h1 class="text-[18px] font-semibold tracking-tight">{user.username}</h1>
         {#if user.role === 'admin'}
-          <span
-            class="bg-amber-500/10 text-amber-400 inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px]"
-          >
+          <Badge variant="warning" class="gap-1 rounded-full px-2">
             <Shield class="h-3 w-3" /> admin
-          </span>
+          </Badge>
         {:else}
-          <span class="bg-muted text-muted-foreground rounded-full px-2 py-0.5 text-[11px]">
-            viewer
-          </span>
+          <Badge variant="secondary" class="rounded-full px-2">viewer</Badge>
         {/if}
         {#if user.deactivated_at}
-          <span class="bg-destructive/10 text-destructive rounded-full px-2 py-0.5 text-[11px]">
+          <Badge
+            variant="destructive"
+            class="bg-destructive/10 text-destructive rounded-full px-2"
+          >
             deactivated
-          </span>
+          </Badge>
         {/if}
         {#if isSelf}
           <span class="text-muted-foreground ml-1 text-[11px]">(you)</span>

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -130,15 +130,16 @@
         <Tooltip.Root>
           <Tooltip.Trigger>
             {#snippet child({ props })}
-              <button
+              <Button
                 {...props}
-                type="button"
+                variant="ghost"
+                size="icon"
                 onclick={() => (paletteOpen = true)}
-                class="text-muted-foreground hover:text-foreground hover:bg-accent inline-flex h-10 w-10 items-center justify-center rounded-md transition-colors"
+                class="text-muted-foreground hover:text-foreground h-10 w-10"
                 aria-label="Search"
               >
                 <Search class="h-[18px] w-[18px]" />
-              </button>
+              </Button>
             {/snippet}
           </Tooltip.Trigger>
           <Tooltip.Content side="right">


### PR DESCRIPTION
## Summary

- Replaces 12 raw `<button>` and 3 DIY badges across 8 feature/route files with the matching `Button` / `Badge` primitives.
- Codifies the rule in `CLAUDE.md`: feature components and routes MUST compose `lib/components/ui/`; raw `<button>`/`<input>`/`<select>`/`<dialog>`/`<label>` and DIY chrome (recreated cards, badges, skeletons, etc.) are forbidden. Missing primitive? Add it to `ui/` first, then consume.

## Files touched

- `web/src/lib/components/IssueList.svelte` — status filter chip + "Clear filters" button
- `web/src/lib/components/IssueRow.svelte` — root-as-button on each list row (visually delicate; uses `tailwind-merge` overrides to preserve layout)
- `web/src/lib/components/ProjectDetail.svelte` — "copy a curl" inline action
- `web/src/lib/components/Toaster.svelte` — undo + close
- `web/src/lib/components/CommandPalette.svelte` — command item rows
- `web/src/lib/components/ProjectSelector.svelte` — rail trigger, inline trigger, per-project menu items
- `web/src/lib/components/UserDetail.svelte` — admin / viewer / deactivated status badges
- `web/src/routes/+layout.svelte` — sidebar command palette trigger
- `CLAUDE.md` — new strict rule + escape hatch under "Style — frontend" and "What NOT to do"

## Deferred to a follow-up PR

These are flagged as soft signals in the audit but don't have a clean 1:1 primitive swap — they need new primitive design first:

- **CommandPalette search input** — needs a bare/borderless `Input` variant (current primitive forces `h-7 + border + rounded-md + padding`).
- **DIY card containers** in `ProjectDetail`, `UserDetail`, `DeleteProjectModal` — need a compact `Card` variant (current primitive is `rounded-xl + ring-1 + py-4`).
- **`<kbd>` and code-block usages** — need new `Kbd` and `CodeBlock` primitives.

## Test plan

- [x] `bun run test` — 102/102 passing
- [x] `bun run check` (svelte-check) — 0 errors, 0 warnings
- [x] `bun run build` — production build clean
- [ ] Visual spot check in `bun run dev` against a running daemon: IssueRow hover/selected states, command palette navigation, toaster interactions, project selector rail/inline, UserDetail badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)