### PR TITLE
feat(web): AI context export, denser rows, rail polish

### DIFF
--- a/web/src/lib/admin.svelte.ts
+++ b/web/src/lib/admin.svelte.ts
@@ -77,6 +77,16 @@ class AdminStore {
   getActivity(name: string): Promise<ActivityStats> {
     return api.admin.getActivity(name);
   }
+
+  /** Bump cached `last_used_at` in place when a fresh event lands over WS.
+   *  Avoids waiting for the next periodic refresh to clear "no events yet". */
+  bumpUsed(name: string, when: string): void {
+    const idx = this.projects.findIndex((p) => p.name === name);
+    if (idx === -1) return;
+    const cur = this.projects[idx]!;
+    if (cur.last_used_at && Date.parse(cur.last_used_at) >= Date.parse(when)) return;
+    this.projects[idx] = { ...cur, last_used_at: when };
+  }
 }
 
 function mapError(err: unknown): AdminError {

--- a/web/src/lib/aiContext.test.ts
+++ b/web/src/lib/aiContext.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { formatIssueContext } from './aiContext';
+import type { Issue, NormalizedEvent, StoredEvent } from './types';
+
+const baseIssue: Issue = {
+  id: 42,
+  project: 'web-frontend',
+  fingerprint: '76a0087db05f2ac8',
+  title: 'TypeError: oops',
+  culprit: 'formatPlan in src/lib/billing.ts',
+  level: 'error',
+  status: 'unresolved',
+  event_count: 7,
+  first_seen: '2026-04-27T03:00:00Z',
+  last_seen: '2026-04-27T04:30:00Z'
+};
+
+function makeEvent(payload: Record<string, unknown>): NormalizedEvent {
+  const stored: StoredEvent = {
+    event_id: 'eid-1',
+    received_at: '2026-04-27T04:30:01Z',
+    payload: payload as never
+  };
+  return {
+    event_id: 'eid-1',
+    received_at: '2026-04-27T04:30:01Z',
+    level: 'error',
+    release: 'web@1.2.3',
+    environment: 'production',
+    exception: {
+      type: 'TypeError',
+      value: 'oops',
+      frames: [
+        { function: 'a', filename: 'a.ts', lineno: 1, in_app: true },
+        { function: 'b', filename: 'b.ts', lineno: 2, in_app: false }
+      ]
+    },
+    breadcrumbs: [
+      { timestamp: '2026-04-27T04:29:00Z', category: 'navigation', message: '/' },
+      { timestamp: '2026-04-27T04:29:30Z', category: 'ui.click', message: 'btn.retry' }
+    ],
+    tags: { browser: 'Chrome 134', os: 'macOS 15.3' },
+    raw: stored
+  };
+}
+
+describe('formatIssueContext', () => {
+  it('renders the core sections when event is present', () => {
+    const ev = makeEvent({
+      contexts: {
+        os: { name: 'macOS', version: '15.3' },
+        browser: { name: 'Chrome', version: '134' }
+      },
+      user: { id: 'u1', email: 'a@b.c' },
+      request: { url: 'https://x/y', method: 'GET' }
+    });
+    const out = formatIssueContext(baseIssue, ev);
+
+    expect(out).toContain('# TypeError: oops');
+    expect(out).toContain('Project: web-frontend');
+    expect(out).toContain('Fingerprint: 76a0087db05f2ac8');
+    expect(out).toContain('Event count: 7');
+    expect(out).toContain('## Exception');
+    expect(out).toContain('TypeError');
+    expect(out).toContain('## Stack trace');
+    expect(out).toContain('a.ts:1');
+    expect(out).toContain('## Breadcrumbs');
+    expect(out).toContain('navigation');
+    expect(out).toContain('btn.retry');
+    expect(out).toContain('## Tags');
+    expect(out).toContain('browser: Chrome 134');
+    expect(out).toContain('## Context');
+    expect(out).toContain('macOS');
+    expect(out).toContain('## User');
+    expect(out).toContain('a@b.c');
+    expect(out).toContain('## Request');
+    expect(out).toContain('https://x/y');
+    expect(out).toContain('## Raw payload');
+  });
+
+  it('falls back to issue-only output when event is null', () => {
+    const out = formatIssueContext(baseIssue, null);
+    expect(out).toContain('# TypeError: oops');
+    expect(out).toContain('No event payload available');
+    expect(out).not.toContain('## Stack trace');
+  });
+
+  it('marks in-app frames distinctly', () => {
+    const out = formatIssueContext(baseIssue, makeEvent({}));
+    expect(out).toMatch(/a\.ts:1.*in_app/);
+    expect(out).not.toMatch(/b\.ts:2.*in_app/);
+  });
+
+  it('omits empty optional sections cleanly', () => {
+    const ev = makeEvent({});
+    // Strip out exception and breadcrumbs to check empty handling.
+    const stripped: NormalizedEvent = {
+      ...ev,
+      exception: null,
+      breadcrumbs: [],
+      tags: {}
+    };
+    const out = formatIssueContext(baseIssue, stripped);
+    expect(out).not.toContain('## Stack trace');
+    expect(out).not.toContain('## Breadcrumbs');
+    expect(out).not.toContain('## Tags');
+    // Raw payload always present.
+    expect(out).toContain('## Raw payload');
+  });
+});

--- a/web/src/lib/aiContext.ts
+++ b/web/src/lib/aiContext.ts
@@ -1,0 +1,157 @@
+// Build a markdown bundle that captures an issue + its latest event in a
+// shape ready to paste into an external LLM. Goal: the AI receives every
+// concrete signal a human triager would have — exception, stack, breadcrumb
+// timeline, environment, user, request, and the raw payload as a fallback
+// for fields the formatter doesn't surface explicitly.
+
+import type { Frame, Issue, NormalizedEvent } from './types';
+
+type Json = unknown;
+
+export function formatIssueContext(issue: Issue, event: NormalizedEvent | null): string {
+  const sections: string[] = [];
+
+  sections.push(header(issue, event));
+
+  if (!event) {
+    sections.push('No event payload available — issue exists but no stored event yet.');
+    return sections.join('\n\n');
+  }
+
+  const payload = (event.raw.payload ?? {}) as Record<string, Json>;
+
+  if (event.exception) sections.push(stackSection(event.exception.type, event.exception.value, event.exception.frames));
+  if (event.breadcrumbs.length > 0) sections.push(breadcrumbSection(event.breadcrumbs));
+  if (Object.keys(event.tags).length > 0) sections.push(tagsSection(event.tags));
+
+  const ctx = contextSection(payload, event);
+  if (ctx) sections.push(ctx);
+
+  const usr = userSection(payload['user']);
+  if (usr) sections.push(usr);
+
+  const req = requestSection(payload['request']);
+  if (req) sections.push(req);
+
+  sections.push(rawSection(event.raw));
+
+  return sections.join('\n\n');
+}
+
+function header(issue: Issue, event: NormalizedEvent | null): string {
+  const lines = [
+    `# ${issue.title}`,
+    '',
+    `- Project: ${issue.project}`,
+    `- Status: ${issue.status}`,
+    `- Level: ${issue.level ?? 'unknown'}`,
+    `- Fingerprint: ${issue.fingerprint}`,
+    `- Event count: ${issue.event_count}`,
+    `- First seen: ${issue.first_seen}`,
+    `- Last seen: ${issue.last_seen}`
+  ];
+  if (issue.culprit) lines.push(`- Culprit: ${issue.culprit}`);
+  if (event?.release) lines.push(`- Release: ${event.release}`);
+  if (event?.environment) lines.push(`- Environment: ${event.environment}`);
+  if (event?.received_at) lines.push(`- Received: ${event.received_at}`);
+  return lines.join('\n');
+}
+
+function stackSection(ty: string | null, value: string | null, frames: Frame[]): string {
+  const head = ty || value ? [`## Exception`, `**${ty ?? 'Error'}**${value ? `: ${value}` : ''}`].join('\n\n') : '## Exception';
+  if (frames.length === 0) return head;
+  // Sentry convention: oldest frame first; the most-relevant (innermost) is
+  // last. Number them so the AI can refer to specific frames by index.
+  const lines = frames.map((f, i) => formatFrame(f, i + 1));
+  return `${head}\n\n## Stack trace\n${lines.join('\n')}`;
+}
+
+function formatFrame(f: Frame, n: number): string {
+  const fn = f.function ?? '<anonymous>';
+  const file = f.filename ?? '<unknown>';
+  const loc = f.lineno != null ? `:${f.lineno}${f.colno != null ? `:${f.colno}` : ''}` : '';
+  const flags = f.in_app ? ' in_app' : '';
+  return `${n}. \`${fn}\` — ${file}${loc}${flags}`;
+}
+
+function breadcrumbSection(bcs: NormalizedEvent['breadcrumbs']): string {
+  const lines = bcs.map((b) => {
+    const ts = b.timestamp ?? '—';
+    const cat = b.category ?? 'event';
+    const lvl = b.level ? `/${b.level}` : '';
+    const msg = b.message ?? '';
+    return `- ${ts} [${cat}${lvl}] ${msg}`.trimEnd();
+  });
+  return `## Breadcrumbs (${bcs.length})\n${lines.join('\n')}`;
+}
+
+function tagsSection(tags: Record<string, string>): string {
+  const lines = Object.entries(tags).map(([k, v]) => `- ${k}: ${v}`);
+  return `## Tags\n${lines.join('\n')}`;
+}
+
+function contextSection(payload: Record<string, Json>, event: NormalizedEvent): string | null {
+  const ctxs = (payload['contexts'] ?? null) as Record<string, Record<string, Json>> | null;
+  const lines: string[] = [];
+  if (ctxs) {
+    const os = ctxs['os'];
+    const br = ctxs['browser'];
+    const dev = ctxs['device'];
+    const rt = ctxs['runtime'];
+    const app = ctxs['app'];
+    if (os) lines.push(`- OS: ${stringifyContext(os)}`);
+    if (br) lines.push(`- Browser: ${stringifyContext(br)}`);
+    if (dev) lines.push(`- Device: ${stringifyContext(dev)}`);
+    if (rt) lines.push(`- Runtime: ${stringifyContext(rt)}`);
+    if (app) lines.push(`- App: ${stringifyContext(app)}`);
+  }
+  if (event.release && !lines.some((l) => l.startsWith('- App:'))) {
+    lines.push(`- Release: ${event.release}`);
+  }
+  if (lines.length === 0) return null;
+  return `## Context\n${lines.join('\n')}`;
+}
+
+function stringifyContext(c: Record<string, Json>): string {
+  const name = (c['name'] as string | undefined) ?? '';
+  const version = (c['version'] as string | undefined) ?? '';
+  const extras: string[] = [];
+  for (const [k, v] of Object.entries(c)) {
+    if (k === 'name' || k === 'version' || k === 'type') continue;
+    if (v == null) continue;
+    extras.push(`${k}=${typeof v === 'object' ? JSON.stringify(v) : String(v)}`);
+  }
+  const head = [name, version].filter(Boolean).join(' ');
+  return extras.length > 0 ? `${head} (${extras.join(', ')})` : head || JSON.stringify(c);
+}
+
+function userSection(user: Json): string | null {
+  if (!user || typeof user !== 'object') return null;
+  const obj = user as Record<string, Json>;
+  const lines = Object.entries(obj)
+    .filter(([, v]) => v != null && (typeof v !== 'object' || v !== null))
+    .map(([k, v]) => `- ${k}: ${typeof v === 'object' ? JSON.stringify(v) : String(v)}`);
+  if (lines.length === 0) return null;
+  return `## User\n${lines.join('\n')}`;
+}
+
+function requestSection(request: Json): string | null {
+  if (!request || typeof request !== 'object') return null;
+  const r = request as Record<string, Json>;
+  const lines: string[] = [];
+  if (r['url']) lines.push(`- URL: ${r['url']}`);
+  if (r['method']) lines.push(`- Method: ${r['method']}`);
+  if (r['query_string']) lines.push(`- Query: ${r['query_string']}`);
+  const headers = r['headers'];
+  if (headers && typeof headers === 'object') {
+    for (const [k, v] of Object.entries(headers)) {
+      lines.push(`- ${k}: ${v}`);
+    }
+  }
+  if (lines.length === 0) return null;
+  return `## Request\n${lines.join('\n')}`;
+}
+
+function rawSection(stored: NormalizedEvent['raw']): string {
+  return `## Raw payload\n\`\`\`json\n${JSON.stringify(stored, null, 2)}\n\`\`\``;
+}

--- a/web/src/lib/components/Breadcrumbs.svelte
+++ b/web/src/lib/components/Breadcrumbs.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { Footprints } from 'lucide-svelte';
   import { Badge } from '$lib/components/ui/badge';
   import { Collapsible } from '$lib/components/ui/collapsible';
   import type { Breadcrumb } from '$lib/types';
@@ -27,7 +28,10 @@
 <section>
   <Collapsible bind:open triggerClass="px-3 py-2 sticky top-0 bg-background">
     {#snippet header()}
-      <h2 class="text-[12px] font-semibold uppercase tracking-wider text-muted-foreground">
+      <h2
+        class="flex items-center gap-1.5 text-[12px] font-semibold uppercase tracking-wider text-muted-foreground"
+      >
+        <Footprints class="h-3.5 w-3.5" />
         Breadcrumbs
         <span class="ml-1 text-muted-foreground/70 normal-case">({breadcrumbs.length})</span>
       </h2>

--- a/web/src/lib/components/IssueDetail.svelte
+++ b/web/src/lib/components/IssueDetail.svelte
@@ -3,6 +3,7 @@
     Ban,
     Bell,
     BellOff,
+    Bot,
     Check,
     Link as LinkIcon,
     SquareMousePointer,
@@ -11,6 +12,7 @@
     UserPlus
   } from 'lucide-svelte';
   import { actions } from '$lib/actions.svelte';
+  import { formatIssueContext } from '$lib/aiContext';
   import * as Avatar from '$lib/components/ui/avatar';
   import { Badge } from '$lib/components/ui/badge';
   import { Button } from '$lib/components/ui/button';
@@ -85,6 +87,18 @@
     );
   }
 
+  function onCopyAIContext() {
+    if (!issue) return;
+    const text = formatIssueContext(issue, selection.event);
+    navigator.clipboard?.writeText(text).then(
+      () =>
+        toast.success('AI context copied', {
+          description: `${text.length.toLocaleString()} chars — paste into Claude/ChatGPT`
+        }),
+      () => toast.error('Could not copy')
+    );
+  }
+
   const assigneeInitial = $derived(assignee ? assignee[0]!.toUpperCase() : '');
 </script>
 
@@ -150,6 +164,28 @@
             {#snippet child({ props })}
               <Button
                 {...props}
+                variant="default"
+                size="icon"
+                class="h-9 w-9"
+                aria-label="Copy AI context"
+                onclick={onCopyAIContext}
+                disabled={eventLoading}
+              >
+                <Bot class="h-4 w-4" />
+              </Button>
+            {/snippet}
+          </Tooltip.Trigger>
+          <Tooltip.Content>
+            Copy AI context
+            <kbd class="text-muted-foreground ml-1 font-mono text-[10px]">⌘⇧C</kbd>
+          </Tooltip.Content>
+        </Tooltip.Root>
+
+        <Tooltip.Root>
+          <Tooltip.Trigger>
+            {#snippet child({ props })}
+              <Button
+                {...props}
                 variant="ghost"
                 size="icon"
                 class="h-9 w-9"
@@ -178,31 +214,6 @@
                 variant="ghost"
                 size="icon"
                 class="h-9 w-9"
-                aria-label={issue.status === 'muted' ? 'Reactivate' : 'Mute'}
-                onclick={onMute}
-              >
-                {#if issue.status === 'muted'}
-                  <Bell class="h-4 w-4" />
-                {:else}
-                  <BellOff class="h-4 w-4" />
-                {/if}
-              </Button>
-            {/snippet}
-          </Tooltip.Trigger>
-          <Tooltip.Content>
-            {issue.status === 'muted' ? 'Reactivate' : 'Mute'}
-            <kbd class="text-muted-foreground ml-1 font-mono text-[10px]">M</kbd>
-          </Tooltip.Content>
-        </Tooltip.Root>
-
-        <Tooltip.Root>
-          <Tooltip.Trigger>
-            {#snippet child({ props })}
-              <Button
-                {...props}
-                variant="ghost"
-                size="icon"
-                class="h-9 w-9"
                 aria-label={assignee === actions.me ? 'Unassign' : 'Assign to me'}
                 onclick={onAssign}
               >
@@ -217,6 +228,33 @@
           <Tooltip.Content>
             {assignee === actions.me ? 'Unassign' : 'Assign to me'}
             <kbd class="text-muted-foreground ml-1 font-mono text-[10px]">A</kbd>
+          </Tooltip.Content>
+        </Tooltip.Root>
+
+        <Separator orientation="vertical" class="mx-1 h-6" />
+
+        <Tooltip.Root>
+          <Tooltip.Trigger>
+            {#snippet child({ props })}
+              <Button
+                {...props}
+                variant="ghost"
+                size="icon"
+                class="h-9 w-9"
+                aria-label={issue.status === 'muted' ? 'Reactivate' : 'Mute'}
+                onclick={onMute}
+              >
+                {#if issue.status === 'muted'}
+                  <Bell class="h-4 w-4" />
+                {:else}
+                  <BellOff class="h-4 w-4" />
+                {/if}
+              </Button>
+            {/snippet}
+          </Tooltip.Trigger>
+          <Tooltip.Content>
+            {issue.status === 'muted' ? 'Reactivate' : 'Mute'}
+            <kbd class="text-muted-foreground ml-1 font-mono text-[10px]">M</kbd>
           </Tooltip.Content>
         </Tooltip.Root>
 

--- a/web/src/lib/components/IssueRow.svelte
+++ b/web/src/lib/components/IssueRow.svelte
@@ -70,7 +70,7 @@
   variant="ghost"
   onclick={() => onSelect?.(issue.id)}
   class={cn(
-    'relative flex h-auto min-h-[60px] w-full justify-start gap-4 whitespace-normal rounded-none px-5 py-3 text-left text-[14px] font-normal',
+    'relative flex h-auto min-h-13 w-full justify-start gap-3 whitespace-normal rounded-none px-4 py-2.5 text-left text-[13px] font-normal',
     'border-b border-border/50',
     "before:absolute before:inset-y-0 before:left-0 before:w-0.5 before:content-['']",
     railClass,
@@ -78,14 +78,14 @@
     isMuted && 'opacity-60'
   )}
 >
-  <span class={cn('h-2.5 w-2.5 shrink-0 rounded-full', dotClass)}></span>
-  <Badge variant={countVariant} class="min-w-[2.75rem] justify-center px-2 py-0.5 text-[12px] tabular-nums">
+  <span class={cn('h-2 w-2 shrink-0 rounded-full', dotClass)}></span>
+  <Badge variant={countVariant} class="min-w-9 justify-center px-1.5 py-0 text-[11px] tabular-nums">
     {issue.event_count}
   </Badge>
-  <div class="flex min-w-0 flex-1 flex-col gap-1">
-    <span class="truncate text-[14px] font-medium leading-snug text-foreground">{issue.title}</span>
+  <div class="flex min-w-0 flex-1 flex-col gap-0.5">
+    <span class="truncate text-[13px] font-medium leading-snug text-foreground">{issue.title}</span>
     {#if issue.culprit}
-      <span class="truncate font-mono text-[12px] leading-snug text-muted-foreground">{issue.culprit}</span>
+      <span class="truncate font-mono text-[11px] leading-snug text-muted-foreground">{issue.culprit}</span>
     {/if}
   </div>
 
@@ -152,8 +152,8 @@
     </Tooltip.Root>
   {/if}
 
-  <Sparkline values={sparkValues} accent={spiking} width={56} height={16} class="shrink-0" />
-  <span class="shrink-0 text-[12px] text-muted-foreground tabular-nums">
+  <Sparkline values={sparkValues} accent={spiking} width={56} height={14} class="shrink-0" />
+  <span class="shrink-0 text-[11px] text-muted-foreground tabular-nums">
     {relativeTime(issue.last_seen)}
   </span>
 </Button>

--- a/web/src/lib/components/KeyboardShortcuts.svelte
+++ b/web/src/lib/components/KeyboardShortcuts.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
   import { actions } from '$lib/actions.svelte';
+  import { formatIssueContext } from '$lib/aiContext';
   import { toggleMute, toggleResolve } from '$lib/issueOps';
   import { selectIssue } from '$lib/selection';
   import { issues, projects, selection, visibleIssues } from '$lib/stores.svelte';
@@ -39,6 +40,23 @@
     if (meta && (e.key === 'k' || e.key === 'K')) {
       e.preventDefault();
       onOpenPalette();
+      return;
+    }
+
+    // Cmd/Ctrl+Shift+C: copy AI context for the selected issue. Global
+    // (works from inputs too) so the user can yank context mid-search.
+    if (meta && e.shiftKey && (e.key === 'c' || e.key === 'C')) {
+      const issue = selectedIssue();
+      if (!issue) return;
+      e.preventDefault();
+      const text = formatIssueContext(issue, selection.event);
+      navigator.clipboard?.writeText(text).then(
+        () =>
+          toast.success('AI context copied', {
+            description: `${text.length.toLocaleString()} chars`
+          }),
+        () => toast.error('Could not copy')
+      );
       return;
     }
 

--- a/web/src/lib/components/ProjectRail.svelte
+++ b/web/src/lib/components/ProjectRail.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
-  import { Loader2, Plus, Webhook } from 'lucide-svelte';
+  import { ListTree, Loader2, Plus, Webhook } from 'lucide-svelte';
   import { goto } from '$app/navigation';
   import { admin } from '$lib/admin.svelte';
   import { Button } from '$lib/components/ui/button';
   import { Input } from '$lib/components/ui/input';
+  import * as Tooltip from '$lib/components/ui/tooltip';
   import { projectActivityStatus } from '$lib/projectsConsole';
   import { toast } from '$lib/toast.svelte';
   import { cn, relativeTime } from '$lib/utils';
+  import { connect } from '$lib/ws';
 
   type Props = { activeName: string | null };
   let { activeName }: Props = $props();
@@ -33,12 +35,23 @@
 
   // Tick every 30s so "live → recent → idle" decays without a refetch.
   // The DB backing data hasn't changed; we just need the derived label
-  // to re-evaluate against a newer `Date.now()`.
+  // to re-evaluate against a newer `Date.now()`. Same tick also pulls a
+  // fresh admin list so cross-project `last_used_at` doesn't go stale —
+  // WS only delivers issues for `projects.current`, so projects you're
+  // not viewing would otherwise never refresh.
   let tick = $state(0);
   $effect(() => {
-    const id = setInterval(() => (tick += 1), 30_000);
+    const id = setInterval(() => {
+      tick += 1;
+      void admin.loadProjects();
+    }, 30_000);
     return () => clearInterval(id);
   });
+
+  function viewIssues(name: string) {
+    connect(name);
+    void goto('/');
+  }
 
   async function createProject(e: SubmitEvent) {
     e.preventDefault();
@@ -74,33 +87,58 @@
       {@const status = projectActivityStatus(p.last_used_at, Date.now() + tick * 0)}
       {@const isActive = p.name === activeName}
       <li>
-        <a
-          href={`/projects/${encodeURIComponent(p.name)}`}
+        <div
           class={cn(
-            'border-border hover:bg-accent/40 flex flex-col gap-1 border-b px-4 py-3 transition-colors',
-            isActive && 'bg-accent/60 border-l-2 border-l-emerald-500 pl-[14px]'
+            'border-border hover:bg-accent/40 group/row flex items-stretch border-b transition-colors',
+            isActive && 'bg-accent/60 border-l-2 border-l-emerald-500'
           )}
-          aria-current={isActive ? 'page' : undefined}
         >
-          <span class="flex items-center gap-2">
-            <span
-              class={cn('h-2 w-2 shrink-0 rounded-full', status.tone)}
-              title={status.label}
-              aria-hidden="true"
-            ></span>
-            <span class="truncate font-mono text-[13px]">{p.name}</span>
-            {#if p.webhook_url}
-              <Webhook class="text-emerald-500 ml-auto h-3 w-3 shrink-0" aria-label="webhook configured" />
-            {/if}
-          </span>
-          <span class="text-muted-foreground text-[11px]">
-            {#if p.last_used_at}
-              last event {relativeTime(p.last_used_at)}
-            {:else}
-              no events yet
-            {/if}
-          </span>
-        </a>
+          <a
+            href={`/projects/${encodeURIComponent(p.name)}`}
+            class={cn(
+              'flex min-w-0 flex-1 flex-col gap-1 px-4 py-3',
+              isActive && 'pl-3.5'
+            )}
+            aria-current={isActive ? 'page' : undefined}
+          >
+            <span class="flex items-center gap-2">
+              <span
+                class={cn('h-2 w-2 shrink-0 rounded-full', status.tone)}
+                title={status.label}
+                aria-hidden="true"
+              ></span>
+              <span class="truncate font-mono text-[13px]">{p.name}</span>
+              {#if p.webhook_url}
+                <Webhook class="text-emerald-500 ml-auto h-3 w-3 shrink-0" aria-label="webhook configured" />
+              {/if}
+            </span>
+            <span class="text-muted-foreground text-[11px]">
+              {#if p.last_used_at}
+                last event {relativeTime(p.last_used_at)}
+              {:else}
+                no events yet
+              {/if}
+            </span>
+          </a>
+          <Tooltip.Root>
+            <Tooltip.Trigger>
+              {#snippet child({ props })}
+                <Button
+                  {...props}
+                  variant="ghost"
+                  size="icon"
+                  onclick={() => viewIssues(p.name)}
+                  aria-label={`View issues for ${p.name}`}
+                  class="my-2 mr-2 h-8 w-8 self-center opacity-0 transition-opacity group-hover/row:opacity-100 focus-visible:opacity-100 data-[active=true]:opacity-100"
+                  data-active={isActive}
+                >
+                  <ListTree class="h-4 w-4" />
+                </Button>
+              {/snippet}
+            </Tooltip.Trigger>
+            <Tooltip.Content>View issues</Tooltip.Content>
+          </Tooltip.Root>
+        </div>
       </li>
     {/each}
 

--- a/web/src/lib/components/StackTrace.svelte
+++ b/web/src/lib/components/StackTrace.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { Layers } from 'lucide-svelte';
   import StackFrame from './StackFrame.svelte';
   import type { Stack } from '$lib/types';
 
@@ -8,7 +9,10 @@
 
 <section class="flex flex-col">
   <header class="border-b border-border px-3 py-2">
-    <h2 class="text-[12px] font-semibold uppercase tracking-wider text-muted-foreground">
+    <h2
+      class="flex items-center gap-1.5 text-[12px] font-semibold uppercase tracking-wider text-muted-foreground"
+    >
+      <Layers class="h-3.5 w-3.5" />
       Stack trace
     </h2>
     {#if exception?.type || exception?.value}

--- a/web/src/lib/components/Tags.svelte
+++ b/web/src/lib/components/Tags.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { Tag } from 'lucide-svelte';
   import { Badge } from '$lib/components/ui/badge';
 
   type Props = { tags: Record<string, string> };
@@ -8,7 +9,12 @@
 </script>
 
 <section class="px-3 py-2">
-  <h2 class="text-[12px] font-semibold uppercase tracking-wider text-muted-foreground">Tags</h2>
+  <h2
+    class="flex items-center gap-1.5 text-[12px] font-semibold uppercase tracking-wider text-muted-foreground"
+  >
+    <Tag class="h-3.5 w-3.5" />
+    Tags
+  </h2>
   {#if entries.length === 0}
     <p class="text-muted-foreground mt-1 text-[12px]">Sem tags neste evento.</p>
   {:else}

--- a/web/src/lib/eventDetail.ts
+++ b/web/src/lib/eventDetail.ts
@@ -22,7 +22,8 @@ export function normalize(stored: StoredEvent): NormalizedEvent {
     environment: p.environment ?? null,
     exception: extractStack(p),
     breadcrumbs: extractBreadcrumbs(p),
-    tags: extractTags(p)
+    tags: extractTags(p),
+    raw: stored
   };
 }
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -112,4 +112,8 @@ export interface NormalizedEvent {
   exception: Stack | null;
   breadcrumbs: Breadcrumb[];
   tags: Record<string, string>;
+  /** Untouched payload as returned by the daemon. Kept so consumers can
+   *  reach fields the normalized view-model intentionally drops (contexts,
+   *  user, request, message) — used by the AI-context exporter. */
+  raw: StoredEvent;
 }

--- a/web/src/lib/ws.ts
+++ b/web/src/lib/ws.ts
@@ -1,5 +1,6 @@
 import { browser } from '$app/environment';
 
+import { admin } from './admin.svelte';
 import { eventStream } from './eventStream.svelte';
 import { connection, issues, load, projects } from './stores.svelte';
 import type { ServerMessage } from './types';
@@ -133,6 +134,7 @@ function handle(msg: ServerMessage) {
     case 'issue_updated':
       issues.upsert(msg.issue);
       eventStream.record(msg.issue.id);
+      admin.bumpUsed(msg.issue.project, msg.issue.last_seen);
       return;
   }
 }

--- a/web/src/routes/issues/[id]/+page.svelte
+++ b/web/src/routes/issues/[id]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { getContext, onMount } from 'svelte';
+  import { getContext, onMount, untrack } from 'svelte';
   import IssueDetail from '$lib/components/IssueDetail.svelte';
   import IssueList from '$lib/components/IssueList.svelte';
   import { Resizable } from '$lib/components/ui/resizable';
@@ -12,16 +12,18 @@
   let leftPercent = $state(40);
   const filterRef = getContext<{ current: HTMLInputElement | null }>('filterRef');
 
-  // Sync the URL parameter into our selection store. The `selectIssue`
-  // helper is idempotent — calling it with the current id is a no-op — so
-  // running it both onMount and on $effect (for client-side navigations)
-  // keeps the deep-link case correct without spamming requests.
+  // Sync the URL parameter into our selection store. `untrack` is critical:
+  // selectIssue reads selection.issueId internally, which would otherwise
+  // make this effect rerun on every selection change and bounce the URL
+  // value back over an in-list click (handleSelect → selectIssue mutates
+  // issueId → effect re-fires with stale data.id → re-selects old row).
   onMount(() => {
     if (data.id != null) selectIssue(data.id);
   });
 
   $effect(() => {
-    if (data.id != null) selectIssue(data.id);
+    const id = data.id;
+    if (id != null) untrack(() => selectIssue(id));
   });
 
   const selectedIssue = $derived(


### PR DESCRIPTION
## Summary
- New AI-context export (`formatIssueContext` + Bot button + ⌘⇧C) that bundles exception, stack, breadcrumbs, tags, contexts, user, request, and raw payload as paste-ready markdown for external LLMs.
- Issue list densification, section icons in the detail pane, project rail "View issues" shortcut, cross-project `last_used_at` freshness via WS bumps + 30s admin refresh.
- Bug fix: clicking an issue on `/issues/[id]` could revert the right pane to the previous issue because the page's `\$effect` was tracking `selection.issueId` through `selectIssue`'s own read. Inner call now wrapped in `untrack`.
- Toolbar reordered by triage priority: AI context (primary) → Resolve → Assign → separator → Mute → Copy link.

## Test plan
- [x] `bun test src/lib/aiContext.test.ts` — 4 pass (29 expectations)
- [x] `bun run check` — 0 errors, 0 warnings
- [x] Click an issue in the list, confirm right pane updates to the new issue (regression covered manually via Chrome DevTools)
- [x] Send a fresh envelope, confirm rail's "last event" updates without reload
- [x] Click Bot button → toast shows char count, clipboard contains the markdown bundle
- [ ] (reviewer) sanity-check the toolbar order and tooltip copy in light + dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)