### PR TITLE
feat(web): denser issue detail header, T-0 breadcrumbs, stack partition

### DIFF
--- a/web/src/lib/components/Breadcrumbs.svelte
+++ b/web/src/lib/components/Breadcrumbs.svelte
@@ -2,13 +2,36 @@
   import { Footprints } from 'lucide-svelte';
   import { Badge } from '$lib/components/ui/badge';
   import { Collapsible } from '$lib/components/ui/collapsible';
+  import { breadcrumbRelativeTime } from '$lib/eventDetail';
   import type { Breadcrumb } from '$lib/types';
-  import { formatTimestamp } from '$lib/utils';
+  import { cn } from '$lib/utils';
 
-  type Props = { breadcrumbs: Breadcrumb[] };
-  let { breadcrumbs }: Props = $props();
+  type Props = { breadcrumbs: Breadcrumb[]; crashTimestamp?: string | null };
+  let { breadcrumbs, crashTimestamp = null }: Props = $props();
 
   let open = $state(true);
+
+  // Anchor index: the breadcrumb closest to (and ≤) the crash timestamp.
+  // That row is the "last thing the user did before it broke", which we
+  // subtly highlight so the eye lands on it without hunting.
+  const anchorIndex = $derived.by(() => {
+    if (!crashTimestamp || breadcrumbs.length === 0) return -1;
+    const crash = Date.parse(crashTimestamp);
+    if (!Number.isFinite(crash)) return -1;
+    let best = -1;
+    let bestDelta = Number.POSITIVE_INFINITY;
+    breadcrumbs.forEach((bc, i) => {
+      if (!bc.timestamp) return;
+      const t = Date.parse(bc.timestamp);
+      if (!Number.isFinite(t) || t > crash) return;
+      const d = crash - t;
+      if (d < bestDelta) {
+        bestDelta = d;
+        best = i;
+      }
+    });
+    return best;
+  });
 
   function levelVariant(level: string | null): 'info' | 'warning' | 'destructive' | 'outline' {
     switch (level) {
@@ -38,15 +61,25 @@
     {/snippet}
 
     {#if breadcrumbs.length === 0}
-      <p class="text-muted-foreground px-3 pb-3 text-[12px]">Sem breadcrumbs neste evento.</p>
+      <p class="text-muted-foreground px-3 pb-3 text-[12px]">No breadcrumbs for this event.</p>
     {:else}
       <ol class="flex flex-col">
         {#each breadcrumbs as bc, i (i)}
+          {@const isAnchor = i === anchorIndex}
           <li
-            class="flex items-start gap-2 border-t border-border/40 px-3 py-1.5 first:border-t-0"
+            class={cn(
+              'flex items-start gap-2 border-t border-border/40 px-3 py-1.5 first:border-t-0',
+              isAnchor && 'border-l-2 border-l-amber-500 bg-amber-500/5 pl-2.5'
+            )}
           >
-            <span class="text-muted-foreground shrink-0 font-mono text-[11px] tabular-nums">
-              {bc.timestamp ? formatTimestamp(bc.timestamp) : '—'}
+            <span
+              class={cn(
+                'shrink-0 font-mono text-[11px] tabular-nums',
+                isAnchor ? 'text-amber-500 font-semibold' : 'text-muted-foreground'
+              )}
+              aria-label={isAnchor ? 'last breadcrumb before the crash' : undefined}
+            >
+              {crashTimestamp ? breadcrumbRelativeTime(crashTimestamp, bc.timestamp) : (bc.timestamp ?? '—')}
             </span>
             <Badge variant={levelVariant(bc.level ?? null)} class="shrink-0">
               {bc.category ?? 'event'}

--- a/web/src/lib/components/IssueDetail.svelte
+++ b/web/src/lib/components/IssueDetail.svelte
@@ -124,6 +124,16 @@
             {issue.level}
           </Badge>
         {/if}
+        {#if event?.environment}
+          <Badge variant="outline" class="px-2 py-0.5 text-[11px] uppercase tracking-wide">
+            {event.environment}
+          </Badge>
+        {/if}
+        {#if event?.release}
+          <Badge variant="outline" class="px-2 py-0.5 font-mono text-[11px]">
+            {event.release}
+          </Badge>
+        {/if}
         {#if issue.status === 'resolved'}
           <Badge variant="outline" class="gap-1.5 px-2 py-0.5 text-[11px]">
             <Check class="text-emerald-500 h-3.5 w-3.5" /> resolved
@@ -153,9 +163,13 @@
 
       <p class="text-muted-foreground text-[11px]">
         <span class="font-mono">#{shortFingerprint(issue.fingerprint)}</span>
-        · {issue.event_count} evt
-        · 1st {relativeTime(issue.first_seen)}
-        · last {relativeTime(issue.last_seen)}
+        {#if issue.event_count <= 1}
+          · seen {relativeTime(issue.last_seen)}
+        {:else}
+          · {issue.event_count} events
+          · 1st {relativeTime(issue.first_seen)}
+          · last {relativeTime(issue.last_seen)}
+        {/if}
       </p>
 
       <div class="mt-2 flex items-center gap-1.5">
@@ -281,7 +295,10 @@
     <div class="flex-1 overflow-y-auto">
       <StackTrace exception={event?.exception ?? null} loading={eventLoading} />
       <Separator />
-      <Breadcrumbs breadcrumbs={event?.breadcrumbs ?? []} />
+      <Breadcrumbs
+        breadcrumbs={event?.breadcrumbs ?? []}
+        crashTimestamp={event?.raw.payload.timestamp ?? event?.received_at ?? null}
+      />
       <Separator />
       <Tags tags={event?.tags ?? {}} />
     </div>

--- a/web/src/lib/components/StackTrace.svelte
+++ b/web/src/lib/components/StackTrace.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
   import { Layers } from 'lucide-svelte';
+  import { partitionFrames } from '$lib/eventDetail';
   import StackFrame from './StackFrame.svelte';
   import type { Stack } from '$lib/types';
 
   type Props = { exception: Stack | null; loading?: boolean };
   let { exception, loading = false }: Props = $props();
+
+  const partition = $derived(partitionFrames(exception?.frames ?? []));
 </script>
 
 <section class="flex flex-col">
@@ -14,6 +17,11 @@
     >
       <Layers class="h-3.5 w-3.5" />
       Stack trace
+      {#if partition.inApp + partition.lib > 0}
+        <span class="ml-1 text-muted-foreground/70 normal-case tracking-normal">
+          {partition.inApp} in your code{partition.lib > 0 ? ` · ${partition.lib} lib` : ''}
+        </span>
+      {/if}
     </h2>
     {#if exception?.type || exception?.value}
       <p class="mt-1 font-mono text-[12px]">

--- a/web/src/lib/components/Tags.svelte
+++ b/web/src/lib/components/Tags.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
   import { Tag } from 'lucide-svelte';
   import { Badge } from '$lib/components/ui/badge';
+  import { dedupTags } from '$lib/eventDetail';
 
   type Props = { tags: Record<string, string> };
   let { tags }: Props = $props();
 
-  const entries = $derived(Object.entries(tags));
+  const entries = $derived(Object.entries(dedupTags(tags)));
 </script>
 
 <section class="px-3 py-2">

--- a/web/src/lib/eventDetail.test.ts
+++ b/web/src/lib/eventDetail.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { breadcrumbRelativeTime, dedupTags, partitionFrames } from './eventDetail';
+import type { Frame } from './types';
+
+describe('dedupTags', () => {
+  it('drops `x.name` when `x` is also present', () => {
+    const out = dedupTags({
+      browser: 'Chrome 134',
+      'browser.name': 'Chrome',
+      os: 'macOS 15.3',
+      'os.name': 'macOS'
+    });
+    expect(out).toEqual({ browser: 'Chrome 134', os: 'macOS 15.3' });
+  });
+
+  it('keeps unrelated `.name` keys', () => {
+    const out = dedupTags({ 'feature.name': 'billing' });
+    expect(out).toEqual({ 'feature.name': 'billing' });
+  });
+
+  it('drops `device.family` when `device` is present', () => {
+    const out = dedupTags({ device: 'MacBookPro18,3', 'device.family': 'Mac' });
+    expect(out).toEqual({ device: 'MacBookPro18,3' });
+  });
+
+  it('handles empty input', () => {
+    expect(dedupTags({})).toEqual({});
+  });
+});
+
+describe('breadcrumbRelativeTime', () => {
+  const crash = '2026-04-27T04:19:31.000Z';
+
+  it('returns T-0 for the crash timestamp itself', () => {
+    expect(breadcrumbRelativeTime(crash, crash)).toBe('T-0');
+  });
+
+  it('returns negative seconds for breadcrumbs before the crash', () => {
+    expect(breadcrumbRelativeTime(crash, '2026-04-27T04:18:49.000Z')).toBe('-42s');
+    expect(breadcrumbRelativeTime(crash, '2026-04-27T04:19:30.000Z')).toBe('-1s');
+  });
+
+  it('falls back to em-dash when breadcrumb timestamp is missing', () => {
+    expect(breadcrumbRelativeTime(crash, undefined)).toBe('—');
+    expect(breadcrumbRelativeTime(crash, null)).toBe('—');
+  });
+
+  it('switches to minutes past 90 seconds', () => {
+    expect(breadcrumbRelativeTime(crash, '2026-04-27T04:17:00.000Z')).toBe('-2m31s');
+    expect(breadcrumbRelativeTime(crash, '2026-04-27T04:00:00.000Z')).toBe('-19m31s');
+  });
+
+  it('handles breadcrumbs after the crash with positive prefix', () => {
+    expect(breadcrumbRelativeTime(crash, '2026-04-27T04:19:33.000Z')).toBe('+2s');
+  });
+});
+
+describe('partitionFrames', () => {
+  function frame(in_app: boolean | null | undefined): Frame {
+    return { function: 'f', filename: 'a.ts', in_app };
+  }
+
+  it('counts in_app vs library frames', () => {
+    const out = partitionFrames([frame(true), frame(true), frame(false), frame(null)]);
+    expect(out).toEqual({ inApp: 2, lib: 2 });
+  });
+
+  it('treats undefined/null in_app as library frames', () => {
+    expect(partitionFrames([frame(undefined)])).toEqual({ inApp: 0, lib: 1 });
+  });
+
+  it('handles empty input', () => {
+    expect(partitionFrames([])).toEqual({ inApp: 0, lib: 0 });
+  });
+});

--- a/web/src/lib/eventDetail.ts
+++ b/web/src/lib/eventDetail.ts
@@ -6,6 +6,7 @@
 import type {
   Breadcrumb,
   EventPayload,
+  Frame,
   IssueLevel,
   NormalizedEvent,
   Stack,
@@ -60,4 +61,64 @@ function extractTags(p: EventPayload): Record<string, string> {
   const out: Record<string, string> = {};
   for (const [k, v] of Object.entries(t)) out[k] = String(v);
   return out;
+}
+
+/**
+ * Drop redundant `x.name` keys when `x` is already present. Sentry SDKs
+ * commonly emit both — `os` carrying "macOS 15.3" and `os.name` carrying
+ * "macOS" — which doubles the badge wall for no information gain. Same
+ * goes for `device.family` when `device` already names the model.
+ */
+export function dedupTags(tags: Record<string, string>): Record<string, string> {
+  const keys = new Set(Object.keys(tags));
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(tags)) {
+    const dot = k.indexOf('.');
+    if (dot > 0) {
+      const prefix = k.slice(0, dot);
+      const suffix = k.slice(dot + 1);
+      if ((suffix === 'name' || suffix === 'family') && keys.has(prefix)) continue;
+    }
+    out[k] = v;
+  }
+  return out;
+}
+
+/**
+ * Format a breadcrumb timestamp as a delta against the crash event so the
+ * user reads "-42s" instead of doing wall-clock math against an absolute
+ * `01:18:49.203`. T-0 is reserved for the breadcrumb that lands on the
+ * crash itself; positive deltas (rare — usually clock skew) get a `+`.
+ */
+export function breadcrumbRelativeTime(
+  crashTs: string,
+  bcTs: string | null | undefined
+): string {
+  if (!bcTs) return '—';
+  const crash = Date.parse(crashTs);
+  const bc = Date.parse(bcTs);
+  if (!Number.isFinite(crash) || !Number.isFinite(bc)) return '—';
+  const deltaMs = bc - crash;
+  if (deltaMs === 0) return 'T-0';
+  const sign = deltaMs > 0 ? '+' : '-';
+  const absSec = Math.round(Math.abs(deltaMs) / 1000);
+  if (absSec < 90) return `${sign}${absSec}s`;
+  const m = Math.floor(absSec / 60);
+  const s = absSec % 60;
+  return s === 0 ? `${sign}${m}m` : `${sign}${m}m${s}s`;
+}
+
+/**
+ * Split frames into "your code" (in_app=true) vs "dependencies"
+ * (in_app=false / null / undefined). The header `N in your code` is the
+ * fastest way to answer "is this mine to fix?" before reading the trace.
+ */
+export function partitionFrames(frames: Frame[]): { inApp: number; lib: number } {
+  let inApp = 0;
+  let lib = 0;
+  for (const f of frames) {
+    if (f.in_app === true) inApp += 1;
+    else lib += 1;
+  }
+  return { inApp, lib };
 }


### PR DESCRIPTION
## Summary
- Tag wall dedup: drop `x.name` / `x.family` when `x` already covers the same info (11 → 8 badges on the user-journey fixture).
- Breadcrumbs render as deltas against the crash (`-42s`, `-1s`, `T-0`) instead of absolute wall-clock. The breadcrumb closest to the crash is highlighted with a left amber border so the eye lands on it.
- Stack heading now shows `N in your code · M lib` so the operator answers "is this mine to fix?" before reading the trace.
- Issue header gets `environment` + `release` outline badges next to the level — the data was already in the payload, just hidden behind the AI-context export.
- Meta line collapses `1st X ago · last X ago` to `seen X ago` when event_count == 1.

## Test plan
- [x] `bun test src/lib/eventDetail.test.ts src/lib/aiContext.test.ts` — 16 pass, 44 expectations
- [x] `bun run check` — 0 errors, 0 warnings
- [x] Manual: open the seeded `web-frontend` TypeError with 11 breadcrumbs, confirm the `-1s` row gets the amber anchor, environment + release appear in the header, and the tag wall is shorter
- [x] Manual: open a single-event issue, confirm meta line says `seen X ago` not `1st X · last X`
- [ ] (reviewer) sanity-check anchor selection when an event has no `payload.timestamp` (falls back to `received_at`) and when breadcrumb timestamps are post-crash (clock skew → no anchor, deltas show `+Xs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)