### PR TITLE
fix(web): break ProjectDetail effect loop on test event

### DIFF
--- a/web/src/lib/components/ProjectDetail.svelte
+++ b/web/src/lib/components/ProjectDetail.svelte
@@ -96,8 +96,14 @@
   // `projects.current === project.name` to avoid noise from a stale socket.
   // Debounced to once per second so an event burst doesn't hammer the
   // activity endpoint — the sparkline only ticks at 1h granularity anyway.
-  let lastRefetchAt = $state(0);
-  let pendingRefetch: ReturnType<typeof setTimeout> | null = $state(null);
+  //
+  // `lastRefetchAt` and `pendingRefetch` are deliberately plain `let` (not
+  // `$state`): if they were reactive, the effect's read+write of
+  // `pendingRefetch` inside the same flush would feed back into its own
+  // dep set and trip `effect_update_depth_exceeded` once `admin.bumpUsed`
+  // started churning the `project` prop reference on every WS tick.
+  let lastRefetchAt = 0;
+  let pendingRefetch: ReturnType<typeof setTimeout> | null = null;
   $effect(() => {
     // Touch the dependencies so Svelte tracks them.
     const at = eventStream.lastAt;


### PR DESCRIPTION
## Summary
Clicking "Send test event" on the project detail page raised
`https://svelte.dev/e/effect_update_depth_exceeded`. The activity-refresh
`\$effect` was both reading and writing `pendingRefetch` in the same flush,
and #9's `admin.bumpUsed` (which reassigns `admin.projects[idx]` on every
WS event) made the effect re-fire enough times to trip Svelte 5's depth
guard.

`pendingRefetch` and `lastRefetchAt` are pure timer bookkeeping — nothing
in the template reads them — so demoting from `\$state` to plain `let`
removes the recursive feedback without changing observable behaviour.

## Test plan
- [x] svelte-check shows no new errors on ProjectDetail.svelte
- [x] HMR reload — clicking "Send test event" no longer throws
- [x] Activity sparkline still refreshes within ~1s of a fresh event
- [ ] (reviewer) navigate between projects mid-flight; confirm cleanup still kills the pending timer

🤖 Generated with [Claude Code](https://claude.com/claude-code)