### PR TITLE
feat(web): URL-synced filter with level chips and active readout

### DIFF
--- a/web/src/lib/components/IssueList.svelte
+++ b/web/src/lib/components/IssueList.svelte
@@ -1,12 +1,29 @@
 <script lang="ts">
-  import { Ban, BellOff, Check, Circle, Search, ShieldCheck } from 'lucide-svelte';
+  import {
+    Ban,
+    BellOff,
+    Check,
+    Circle,
+    Search,
+    ShieldCheck,
+    SlidersHorizontal,
+    X
+  } from 'lucide-svelte';
+  import { onMount } from 'svelte';
+  import { browser } from '$app/environment';
+  import { Badge } from '$lib/components/ui/badge';
   import { Button } from '$lib/components/ui/button';
+  import { Checkbox } from '$lib/components/ui/checkbox';
   import { Input } from '$lib/components/ui/input';
+  import { Label } from '$lib/components/ui/label';
+  import * as Popover from '$lib/components/ui/popover';
+  import { Separator } from '$lib/components/ui/separator';
   import { Skeleton } from '$lib/components/ui/skeleton';
   import * as Tooltip from '$lib/components/ui/tooltip';
   import { eventStream } from '$lib/eventStream.svelte';
+  import { parseFilterParams, serializeFilterParams } from '$lib/filterUrl';
   import { filter, issues, load, projects, selection, visibleIssues } from '$lib/stores.svelte';
-  import type { IssueStatus } from '$lib/types';
+  import type { IssueLevel, IssueStatus } from '$lib/types';
   import { cn } from '$lib/utils';
   import IssueRow from './IssueRow.svelte';
 
@@ -21,28 +38,66 @@
     if (filterRef && inputEl) filterRef.current = inputEl;
   });
 
+  // Hydrate filter state from URL once on mount. Subsequent changes flow
+  // the other direction via the effect below; the two never both write in
+  // the same tick because hydration is synchronous before the first
+  // effect run.
+  onMount(() => {
+    if (!browser) return;
+    const next = parseFilterParams(new URLSearchParams(location.search));
+    filter.query = next.query;
+    filter.statuses = next.statuses;
+    filter.levels = next.levels;
+  });
+
+  // Push filter state into the URL so the active filter is reload-safe and
+  // shareable. We use replaceState (not goto) to avoid polluting browser
+  // history on every keystroke and to skip SvelteKit's data revalidation.
+  $effect(() => {
+    if (!browser) return;
+    const params = serializeFilterParams({
+      query: filter.query,
+      statuses: filter.statuses,
+      levels: filter.levels
+    });
+    const search = params.toString();
+    const target = location.pathname + (search ? `?${search}` : '') + location.hash;
+    if (target !== location.pathname + location.search + location.hash) {
+      history.replaceState(history.state, '', target);
+    }
+  });
+
   const visible = $derived(visibleIssues());
 
   type StatusChip = {
     key: IssueStatus;
     label: string;
     Icon: typeof Circle;
+    activeClass: string;
   };
 
-  const chips: StatusChip[] = [
-    { key: 'unresolved', label: 'Unresolved', Icon: Circle },
-    { key: 'resolved', label: 'Resolved', Icon: Check },
-    { key: 'muted', label: 'Muted', Icon: BellOff },
-    { key: 'ignored', label: 'Ignored', Icon: Ban }
+  const statusChips: StatusChip[] = [
+    { key: 'unresolved', label: 'Unresolved', Icon: Circle, activeClass: 'bg-foreground/10 text-foreground ring-1 ring-foreground/30' },
+    { key: 'resolved',   label: 'Resolved',   Icon: Check,  activeClass: 'bg-emerald-500/15 text-emerald-500 ring-1 ring-emerald-500/40' },
+    { key: 'muted',      label: 'Muted',      Icon: BellOff, activeClass: 'bg-amber-500/15 text-amber-500 ring-1 ring-amber-500/40' },
+    { key: 'ignored',    label: 'Ignored',    Icon: Ban,    activeClass: 'bg-muted text-muted-foreground ring-1 ring-border' }
   ];
 
-  function isChecked(s: IssueStatus): boolean {
-    return filter.statuses.has(s);
-  }
+  const allLevels: IssueLevel[] = ['fatal', 'error', 'warning', 'info', 'debug'];
 
   function statusCount(s: IssueStatus): number {
     return issues.list.filter((i) => i.project === projects.current && i.status === s).length;
   }
+
+  function levelCount(l: IssueLevel): number {
+    return issues.list.filter(
+      (i) => i.project === projects.current && (i.level?.toLowerCase() ?? '') === l
+    ).length;
+  }
+
+  const projectTotal = $derived(
+    issues.list.filter((i) => i.project === projects.current).length
+  );
 
   const allClearLabel = $derived.by(() => {
     void eventStream.tick;
@@ -57,50 +112,192 @@
   const hasActiveFilter = $derived(
     filter.query.trim().length > 0 ||
       filter.statuses.size !== 1 ||
-      !filter.statuses.has('unresolved')
+      !filter.statuses.has('unresolved') ||
+      filter.levels.size > 0
   );
+
+  // Stable, human-readable order for the readout: matches the chip row.
+  const STATUS_ORDER: IssueStatus[] = ['unresolved', 'resolved', 'muted', 'ignored'];
+  const LEVEL_ORDER: IssueLevel[] = ['fatal', 'error', 'warning', 'info', 'debug'];
+
+  const statusReadout = $derived(
+    STATUS_ORDER.filter((s) => filter.statuses.has(s)).join(' + ')
+  );
+  const levelReadout = $derived(
+    LEVEL_ORDER.filter((l) => filter.levels.has(l)).join(', ')
+  );
+
+  function clearFilters() {
+    filter.query = '';
+    filter.statuses = new Set<IssueStatus>(['unresolved']);
+    filter.levels = new Set<IssueLevel>();
+  }
 </script>
 
 <div class="flex h-full flex-col">
-  <div class="flex items-center gap-3 border-b border-border px-5 py-3">
+  <div class="flex items-center gap-2 border-b border-border px-3 py-2">
     <div class="relative flex-1">
-      <Search class="text-muted-foreground absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2" />
+      <Search class="text-muted-foreground absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2" />
       <Input
         bind:ref={inputEl}
         bind:value={filter.query}
-        placeholder="filter  /"
-        class="h-10 pl-9 text-[14px]"
+        placeholder="filter"
+        class="h-9 pl-8 pr-16 text-[13px]"
       />
+      {#if filter.query.length > 0}
+        <Button
+          variant="ghost"
+          size="icon"
+          class="absolute right-8 top-1/2 h-6 w-6 -translate-y-1/2 text-muted-foreground"
+          aria-label="Clear filter query"
+          onclick={() => (filter.query = '')}
+        >
+          <X class="h-3.5 w-3.5" />
+        </Button>
+      {:else}
+        <kbd
+          class="border-border text-muted-foreground absolute right-2 top-1/2 -translate-y-1/2 rounded border px-1.5 py-0.5 font-mono text-[10px]"
+          aria-hidden="true"
+        >
+          /
+        </kbd>
+      {/if}
     </div>
-    <div class="flex items-center gap-1.5">
-      {#each chips as chip (chip.key)}
-        {@const on = isChecked(chip.key)}
+
+    <div class="flex items-center gap-1">
+      {#each statusChips as chip (chip.key)}
+        {@const on = filter.statuses.has(chip.key)}
+        {@const count = statusCount(chip.key)}
+        {@const empty = count === 0 && !on}
         <Tooltip.Root>
           <Tooltip.Trigger>
             {#snippet child({ props })}
               <Button
                 {...props}
-                variant="outline"
-                size="icon"
+                variant="ghost"
+                size="sm"
                 onclick={() => filter.toggleStatus(chip.key)}
                 aria-pressed={on}
                 aria-label={chip.label}
                 class={cn(
-                  'h-9 w-9',
+                  'h-9 gap-1.5 px-2 tabular-nums',
                   on
-                    ? 'bg-accent text-foreground'
-                    : 'text-muted-foreground/60 hover:text-foreground hover:bg-accent/50'
+                    ? chip.activeClass
+                    : 'text-muted-foreground hover:text-foreground hover:bg-accent/50',
+                  empty && 'opacity-40'
                 )}
               >
                 <chip.Icon class="h-4 w-4" />
+                <span class="text-[12px]">{count}</span>
               </Button>
             {/snippet}
           </Tooltip.Trigger>
-          <Tooltip.Content>{chip.label} ({statusCount(chip.key)})</Tooltip.Content>
+          <Tooltip.Content>{chip.label}</Tooltip.Content>
         </Tooltip.Root>
       {/each}
+
+      <Separator orientation="vertical" class="mx-1 h-5" />
+
+      <Popover.Root>
+        <Popover.Trigger>
+          {#snippet child({ props })}
+            <Button
+              {...props}
+              variant="ghost"
+              size="sm"
+              aria-label="Filter by level"
+              class={cn(
+                'h-9 gap-1.5 px-2',
+                filter.levels.size > 0
+                  ? 'text-foreground bg-accent ring-1 ring-border'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'
+              )}
+            >
+              <SlidersHorizontal class="h-4 w-4" />
+              {#if filter.levels.size > 0}
+                <Badge variant="outline" class="h-4 px-1 text-[10px] tabular-nums">
+                  {filter.levels.size}
+                </Badge>
+              {/if}
+            </Button>
+          {/snippet}
+        </Popover.Trigger>
+        <Popover.Content class="w-56 p-2">
+          <div class="text-muted-foreground px-2 py-1 text-[11px] font-semibold uppercase tracking-wider">
+            Level
+          </div>
+          <ul class="flex flex-col">
+            {#each allLevels as lvl (lvl)}
+              {@const checked = filter.levels.has(lvl)}
+              {@const count = levelCount(lvl)}
+              <li>
+                <Label
+                  class={cn(
+                    'flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-[12px] hover:bg-accent',
+                    count === 0 && !checked && 'opacity-50'
+                  )}
+                >
+                  <Checkbox
+                    {checked}
+                    onCheckedChange={() => filter.toggleLevel(lvl)}
+                  />
+                  <span class="flex-1 capitalize">{lvl}</span>
+                  <span class="text-muted-foreground tabular-nums text-[11px]">{count}</span>
+                </Label>
+              </li>
+            {/each}
+          </ul>
+          {#if filter.levels.size > 0}
+            <div class="mt-1 border-t border-border pt-1">
+              <Button
+                variant="ghost"
+                size="sm"
+                class="h-7 w-full justify-start text-[12px] text-muted-foreground"
+                onclick={() => (filter.levels = new Set())}
+              >
+                Clear levels
+              </Button>
+            </div>
+          {/if}
+        </Popover.Content>
+      </Popover.Root>
     </div>
   </div>
+
+  {#if hasActiveFilter && !load.initialLoad}
+    <div
+      class="flex flex-wrap items-center gap-x-2 gap-y-1 border-b border-border bg-muted/30 px-3 py-1.5 text-[11px] text-muted-foreground"
+    >
+      <span class="text-foreground tabular-nums font-medium">
+        {visible.length}
+      </span>
+      <span>of</span>
+      <span class="tabular-nums">{projectTotal}</span>
+      {#if filter.query.trim().length > 0}
+        <span class="text-border">·</span>
+        <span>query:</span>
+        <span class="text-foreground font-mono">"{filter.query}"</span>
+      {/if}
+      {#if statusReadout && (filter.statuses.size !== 1 || !filter.statuses.has('unresolved'))}
+        <span class="text-border">·</span>
+        <span>status:</span>
+        <span class="text-foreground">{statusReadout}</span>
+      {/if}
+      {#if levelReadout}
+        <span class="text-border">·</span>
+        <span>level:</span>
+        <span class="text-foreground">{levelReadout}</span>
+      {/if}
+      <Button
+        variant="link"
+        size="sm"
+        class="ml-auto h-auto p-0 text-[11px]"
+        onclick={clearFilters}
+      >
+        Clear all
+      </Button>
+    </div>
+  {/if}
 
   <div class="flex-1 overflow-y-auto">
     {#if load.initialLoad}
@@ -125,13 +322,10 @@
         <Button
           variant="link"
           size="sm"
-          onclick={() => {
-            filter.query = '';
-            filter.statuses = new Set<IssueStatus>(['unresolved']);
-          }}
+          onclick={clearFilters}
           class="h-auto p-0 text-[12px]"
         >
-          Clear filters
+          Clear all filters
         </Button>
       </div>
     {:else if visible.length === 0}

--- a/web/src/lib/filterUrl.test.ts
+++ b/web/src/lib/filterUrl.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import { parseFilterParams, serializeFilterParams } from './filterUrl';
+import type { IssueLevel, IssueStatus } from './types';
+
+const allStatuses: IssueStatus[] = ['unresolved', 'resolved', 'muted', 'ignored'];
+const allLevels: IssueLevel[] = ['debug', 'info', 'warning', 'error', 'fatal'];
+
+describe('serializeFilterParams', () => {
+  it('omits q when blank', () => {
+    const p = serializeFilterParams({
+      query: '',
+      statuses: new Set<IssueStatus>(['unresolved']),
+      levels: new Set<IssueLevel>()
+    });
+    expect(p.has('q')).toBe(false);
+  });
+
+  it('omits s when statuses is the default {unresolved}', () => {
+    const p = serializeFilterParams({
+      query: '',
+      statuses: new Set<IssueStatus>(['unresolved']),
+      levels: new Set<IssueLevel>()
+    });
+    expect(p.has('s')).toBe(false);
+  });
+
+  it('emits s as a sorted CSV when statuses diverge from the default', () => {
+    const p = serializeFilterParams({
+      query: '',
+      statuses: new Set<IssueStatus>(['resolved', 'muted']),
+      levels: new Set<IssueLevel>()
+    });
+    expect(p.get('s')).toBe('muted,resolved');
+  });
+
+  it('omits l when levels is empty', () => {
+    const p = serializeFilterParams({
+      query: '',
+      statuses: new Set<IssueStatus>(['unresolved']),
+      levels: new Set<IssueLevel>()
+    });
+    expect(p.has('l')).toBe(false);
+  });
+
+  it('emits l as a sorted CSV when levels are set', () => {
+    const p = serializeFilterParams({
+      query: '',
+      statuses: new Set<IssueStatus>(['unresolved']),
+      levels: new Set<IssueLevel>(['fatal', 'error'])
+    });
+    expect(p.get('l')).toBe('error,fatal');
+  });
+
+  it('keeps query intact (URLSearchParams handles encoding)', () => {
+    const p = serializeFilterParams({
+      query: 'auth fail',
+      statuses: new Set<IssueStatus>(['unresolved']),
+      levels: new Set<IssueLevel>()
+    });
+    expect(p.get('q')).toBe('auth fail');
+  });
+});
+
+describe('parseFilterParams', () => {
+  it('returns the defaults when nothing is set', () => {
+    const f = parseFilterParams(new URLSearchParams(''));
+    expect(f.query).toBe('');
+    expect([...f.statuses]).toEqual(['unresolved']);
+    expect(f.levels.size).toBe(0);
+  });
+
+  it('parses q', () => {
+    const f = parseFilterParams(new URLSearchParams('q=auth'));
+    expect(f.query).toBe('auth');
+  });
+
+  it('parses s as a CSV of valid IssueStatus tokens; drops unknowns', () => {
+    const f = parseFilterParams(new URLSearchParams('s=resolved,muted,bogus'));
+    expect([...f.statuses].sort()).toEqual(['muted', 'resolved']);
+  });
+
+  it('falls back to {unresolved} when s is present but yields nothing valid', () => {
+    const f = parseFilterParams(new URLSearchParams('s=bogus,xxx'));
+    expect([...f.statuses]).toEqual(['unresolved']);
+  });
+
+  it('parses l as a CSV of valid IssueLevel tokens; drops unknowns', () => {
+    const f = parseFilterParams(new URLSearchParams('l=error,fatal,xxx'));
+    expect([...f.levels].sort()).toEqual(['error', 'fatal']);
+  });
+
+  it('round-trips a non-default state', () => {
+    const initial = {
+      query: 'auth',
+      statuses: new Set<IssueStatus>(['resolved', 'muted']),
+      levels: new Set<IssueLevel>(['error', 'fatal'])
+    };
+    const round = parseFilterParams(serializeFilterParams(initial));
+    expect(round.query).toBe('auth');
+    expect([...round.statuses].sort()).toEqual(['muted', 'resolved']);
+    expect([...round.levels].sort()).toEqual(['error', 'fatal']);
+  });
+
+  it('treats every recognised status/level as round-trippable', () => {
+    for (const s of allStatuses) {
+      const round = parseFilterParams(
+        serializeFilterParams({
+          query: '',
+          statuses: new Set<IssueStatus>([s]),
+          levels: new Set<IssueLevel>()
+        })
+      );
+      expect(round.statuses.has(s)).toBe(true);
+    }
+    for (const l of allLevels) {
+      const round = parseFilterParams(
+        serializeFilterParams({
+          query: '',
+          statuses: new Set<IssueStatus>(['unresolved']),
+          levels: new Set<IssueLevel>([l])
+        })
+      );
+      expect(round.levels.has(l)).toBe(true);
+    }
+  });
+});

--- a/web/src/lib/filterUrl.ts
+++ b/web/src/lib/filterUrl.ts
@@ -1,0 +1,63 @@
+// Serialize/parse the issue list filter to/from URLSearchParams so the
+// active filter is shareable, reload-safe, and bookmarkable. Defaults
+// are omitted from the query string to keep clean URLs the common case.
+
+import type { IssueLevel, IssueStatus } from './types';
+
+export interface FilterState {
+  query: string;
+  statuses: Set<IssueStatus>;
+  levels: Set<IssueLevel>;
+}
+
+const ALL_STATUSES: IssueStatus[] = ['unresolved', 'resolved', 'muted', 'ignored'];
+const ALL_LEVELS: IssueLevel[] = ['debug', 'info', 'warning', 'error', 'fatal'];
+
+function setEqualsDefaultStatuses(s: Set<IssueStatus>): boolean {
+  return s.size === 1 && s.has('unresolved');
+}
+
+function csvSorted<T extends string>(s: Set<T>): string {
+  return [...s].sort().join(',');
+}
+
+export function serializeFilterParams(f: FilterState): URLSearchParams {
+  const p = new URLSearchParams();
+  if (f.query.trim().length > 0) p.set('q', f.query);
+  if (!setEqualsDefaultStatuses(f.statuses)) p.set('s', csvSorted(f.statuses));
+  if (f.levels.size > 0) p.set('l', csvSorted(f.levels));
+  return p;
+}
+
+export function parseFilterParams(p: URLSearchParams): FilterState {
+  const query = p.get('q') ?? '';
+
+  const sRaw = p.get('s');
+  let statuses: Set<IssueStatus>;
+  if (sRaw == null) {
+    statuses = new Set<IssueStatus>(['unresolved']);
+  } else {
+    statuses = new Set<IssueStatus>(
+      sRaw
+        .split(',')
+        .map((t) => t.trim())
+        .filter((t): t is IssueStatus => (ALL_STATUSES as string[]).includes(t))
+    );
+    // Empty after filtering invalid tokens — fall back rather than show
+    // nothing on a malformed share link.
+    if (statuses.size === 0) statuses = new Set<IssueStatus>(['unresolved']);
+  }
+
+  const lRaw = p.get('l');
+  const levels =
+    lRaw == null
+      ? new Set<IssueLevel>()
+      : new Set<IssueLevel>(
+          lRaw
+            .split(',')
+            .map((t) => t.trim())
+            .filter((t): t is IssueLevel => (ALL_LEVELS as string[]).includes(t))
+        );
+
+  return { query, statuses, levels };
+}

--- a/web/src/lib/stores.svelte.ts
+++ b/web/src/lib/stores.svelte.ts
@@ -1,6 +1,7 @@
 import type {
   ConnectionStatus,
   Issue,
+  IssueLevel,
   IssueStatus,
   NormalizedEvent,
   ProjectSummary
@@ -41,12 +42,24 @@ class FilterStore {
   // Default view shows what's actionable; resolved/muted/ignored are hidden
   // until the user opts in. Power users can toggle via the list header.
   statuses = $state<Set<IssueStatus>>(new Set(['unresolved']));
+  // Empty set = no level filter (all levels visible). Non-empty = include
+  // only those levels. Distinct from statuses where the default is a
+  // single-element set, since "no level filter" is the much more common
+  // resting state.
+  levels = $state<Set<IssueLevel>>(new Set());
 
   toggleStatus(s: IssueStatus) {
     const next = new Set(this.statuses);
     if (next.has(s)) next.delete(s);
     else next.add(s);
     this.statuses = next;
+  }
+
+  toggleLevel(l: IssueLevel) {
+    const next = new Set(this.levels);
+    if (next.has(l)) next.delete(l);
+    else next.add(l);
+    this.levels = next;
   }
 }
 
@@ -91,9 +104,17 @@ export const load = new LoadStore();
 // wrong for any team larger than one.
 export function visibleIssues(): Issue[] {
   const q = filter.query.trim().toLowerCase();
+  const levelFilter = filter.levels;
   return issues.list.filter((i) => {
     if (i.project !== projects.current) return false;
     if (!filter.statuses.has(i.status)) return false;
+    if (levelFilter.size > 0) {
+      const lvl = i.level?.toLowerCase() ?? '';
+      // Issues whose level is null can't satisfy a positive level filter;
+      // dropping them is correct — "show me only fatals" should not
+      // accidentally include unlabelled rows.
+      if (!(lvl && levelFilter.has(lvl as IssueLevel))) return false;
+    }
     if (q && !matches(i, q)) return false;
     return true;
   });

--- a/web/src/lib/stores.test.ts
+++ b/web/src/lib/stores.test.ts
@@ -10,7 +10,7 @@ import {
   selection,
   visibleIssues
 } from './stores.svelte';
-import type { Issue, IssueStatus } from './types';
+import type { Issue, IssueLevel, IssueStatus } from './types';
 
 function issue(over: Partial<Issue>): Issue {
   return {
@@ -32,6 +32,7 @@ beforeEach(() => {
   issues.reset([]);
   filter.query = '';
   filter.statuses = new Set<IssueStatus>(['unresolved']);
+  filter.levels = new Set<IssueLevel>();
   projects.current = 'p';
   selection.issueId = null;
   selection.event = null;
@@ -113,5 +114,46 @@ describe('FilterStore.toggleStatus', () => {
     expect(filter.statuses.has('resolved')).toBe(true);
     filter.toggleStatus('resolved');
     expect(filter.statuses.has('resolved')).toBe(false);
+  });
+});
+
+describe('FilterStore.toggleLevel', () => {
+  it('adds and removes levels idempotently', () => {
+    filter.levels = new Set();
+    filter.toggleLevel('error');
+    expect(filter.levels.has('error')).toBe(true);
+    filter.toggleLevel('error');
+    expect(filter.levels.has('error')).toBe(false);
+  });
+});
+
+describe('visibleIssues + level filter', () => {
+  it('keeps all levels when the level filter is empty', () => {
+    issues.reset([
+      issue({ id: 1, level: 'error', status: 'unresolved' }),
+      issue({ id: 2, level: 'warning', status: 'unresolved' }),
+      issue({ id: 3, level: null, status: 'unresolved' })
+    ]);
+    filter.levels = new Set();
+    expect(visibleIssues().map((i) => i.id).sort()).toEqual([1, 2, 3]);
+  });
+
+  it('narrows to selected levels (case-insensitive against issue.level)', () => {
+    issues.reset([
+      issue({ id: 1, level: 'error', status: 'unresolved' }),
+      issue({ id: 2, level: 'WARNING', status: 'unresolved' }),
+      issue({ id: 3, level: 'fatal', status: 'unresolved' })
+    ]);
+    filter.levels = new Set<IssueLevel>(['error', 'fatal']);
+    expect(visibleIssues().map((i) => i.id).sort()).toEqual([1, 3]);
+  });
+
+  it('drops issues whose level is null when a level filter is active', () => {
+    issues.reset([
+      issue({ id: 1, level: null, status: 'unresolved' }),
+      issue({ id: 2, level: 'error', status: 'unresolved' })
+    ]);
+    filter.levels = new Set<IssueLevel>(['error']);
+    expect(visibleIssues().map((i) => i.id)).toEqual([2]);
   });
 });


### PR DESCRIPTION
## Summary
- Add a `levels` axis to `FilterStore` (case-insensitive match against `issue.level`); default empty = no level filter so the resting state is unchanged.
- Round-trip filter state through URL search params (`q`/`s`/`l`) via pure `parseFilterParams` / `serializeFilterParams` helpers — defaults omitted, malformed tokens tolerated, fully tested.
- Rewrite the IssueList filter bar: input gets `<kbd>/</kbd>` shortcut hint and an inline X clear; status chips carry inline counts with semantic hue per status (resolved=emerald, muted=amber, ignored=zinc, unresolved=foreground ring) and dim at zero count; new level filter Popover with checkbox list and per-level counts; padding pulled to `px-3 py-2` to match the denser IssueDetail rhythm.
- New active-filter readout strip above the list: `N of M · query: "x" · status: muted + resolved · level: error, fatal · Clear all`. Renders only when a filter is active so the calm path stays calm.

## Test plan
- [x] `bun run check` clean (svelte-check, 0 errors)
- [x] `bun run test` green (160 tests, +17 new across `stores.test.ts` and `filterUrl.test.ts`)
- [ ] Manual: type into filter, refresh — query persists via URL
- [ ] Manual: toggle status chips, copy URL into a new tab — same view
- [ ] Manual: open level popover, pick `fatal`+`error`, confirm readout + count + URL update
- [ ] Manual: click X clear inside input — only query clears, chips/levels untouched
- [ ] Manual: chips at count=0 dim correctly; clicking still works (lets users opt back in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)