### PR TITLE
feat(web): expand filters + rework ProjectDetail visual hierarchy

### DIFF
--- a/web/src/lib/components/ConnectionStatus.svelte
+++ b/web/src/lib/components/ConnectionStatus.svelte
@@ -9,11 +9,15 @@
     connection.status === 'reconnecting' || connection.status === 'connecting'
   );
 
+  // Silence is good news: connected = muted (same weight as Freshness),
+  // pending = amber pulse, disconnected = destructive. No saturated green
+  // baseline — it competes with the active-nav rail and trains the eye to
+  // ignore real status changes.
   const iconClass = $derived(
     cn(
-      'h-[18px] w-[18px]',
+      'h-4 w-4',
       isConnected
-        ? 'text-emerald-500'
+        ? 'text-muted-foreground/70'
         : isPending
           ? 'text-amber-500 animate-pulse'
           : 'text-destructive'
@@ -29,13 +33,13 @@
 
 <Tooltip.Root>
   <Tooltip.Trigger
-    class="text-muted-foreground hover:text-foreground hover:bg-accent inline-flex h-10 w-10 items-center justify-center rounded-md transition-colors"
+    class="text-muted-foreground/70 inline-flex h-8 w-8 items-center justify-center rounded-md"
     aria-label={label}
   >
     {#if isConnected || isPending}
-      <Wifi class={iconClass} />
+      <Wifi class={iconClass} strokeWidth={1.75} />
     {:else}
-      <WifiOff class={iconClass} />
+      <WifiOff class={iconClass} strokeWidth={1.75} />
     {/if}
   </Tooltip.Trigger>
   <Tooltip.Content side="right">

--- a/web/src/lib/components/Freshness.svelte
+++ b/web/src/lib/components/Freshness.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { RefreshCw } from 'lucide-svelte';
+  import { Activity } from 'lucide-svelte';
   import * as Tooltip from '$lib/components/ui/tooltip';
   import { eventStream } from '$lib/eventStream.svelte';
   import { connection } from '$lib/stores.svelte';
@@ -31,17 +31,21 @@
   });
 </script>
 
+<!-- Status indicator, not a nav button. Smaller, no hover background — read,
+     not click. The Activity icon was picked over RefreshCw because RefreshCw
+     reads as "manual refresh action" and we already push events over WS. -->
 <Tooltip.Root>
   <Tooltip.Trigger
-    class="text-muted-foreground hover:text-foreground hover:bg-accent inline-flex h-10 w-10 items-center justify-center rounded-md transition-colors"
+    class="text-muted-foreground/70 inline-flex h-8 w-8 items-center justify-center rounded-md"
     aria-label={`Last event ${label}`}
   >
-    <RefreshCw
+    <Activity
       class={cn(
-        'h-[18px] w-[18px]',
+        'h-4 w-4',
         stale && 'opacity-50',
-        fresh && 'animate-pulse text-foreground'
+        fresh && 'text-foreground animate-pulse'
       )}
+      strokeWidth={1.75}
     />
   </Tooltip.Trigger>
   <Tooltip.Content side="right">

--- a/web/src/lib/components/HeaderStats.svelte
+++ b/web/src/lib/components/HeaderStats.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
+  import { Activity, AlertTriangle, Flame, PlugZap } from 'lucide-svelte';
+  import { Badge } from '$lib/components/ui/badge';
+  import { Separator } from '$lib/components/ui/separator';
+  import * as Tooltip from '$lib/components/ui/tooltip';
   import { eventStream } from '$lib/eventStream.svelte';
-  import { issues, projects } from '$lib/stores.svelte';
+  import { filter, issues, projects } from '$lib/stores.svelte';
+  import { cn } from '$lib/utils';
   import Sparkline from './Sparkline.svelte';
 
   // The header reads `eventStream.tick` so the counters refresh on the same
@@ -8,9 +13,16 @@
   // would also work but multiplies DOM updates needlessly.
   const ofProject = $derived(issues.list.filter((i) => i.project === projects.current));
 
+  const SINCE_1H = 60 * 60 * 1000;
+  // Anything older than this without a single event means the daemon is
+  // probably not receiving anything — treat that case as "ingest stale" so
+  // a `0 events/min` row does not look identical between "all good" and
+  // "broken pipe".
+  const INGEST_STALE_MS = 5 * 60 * 1000;
+
   const newLastHour = $derived.by(() => {
     void eventStream.tick;
-    const cutoff = Date.now() - 60 * 60 * 1000;
+    const cutoff = Date.now() - SINCE_1H;
     return ofProject.filter(
       (i) => +new Date(i.first_seen) >= cutoff && i.status === 'unresolved'
     ).length;
@@ -30,7 +42,7 @@
   const buckets = $derived.by(() => {
     void eventStream.tick;
     const slots = 60;
-    const window = 60 * 60 * 1000;
+    const window = SINCE_1H;
     const start = Date.now() - window;
     const bucketMs = window / slots;
     const out = new Array<number>(slots).fill(0);
@@ -41,28 +53,150 @@
     }
     return out;
   });
+
+  // True when ingest has been silent for 5+ min OR has never spoken at
+  // all. Distinct from "rate is 0 because the project is quiet" — that
+  // case keeps the rate stat visible.
+  const ingestStale = $derived.by(() => {
+    void eventStream.tick;
+    if (eventStream.lastAt == null) return true;
+    return Date.now() - eventStream.lastAt > INGEST_STALE_MS;
+  });
+
+  function toggleSince1h() {
+    filter.sinceMs = filter.sinceMs === SINCE_1H ? null : SINCE_1H;
+  }
+
+  function toggleSpiking() {
+    filter.spikingOnly = !filter.spikingOnly;
+  }
+
+  const newActive = $derived(filter.sinceMs === SINCE_1H);
+  const spikeActive = $derived(filter.spikingOnly);
 </script>
 
-<div class="flex items-center gap-5">
-  <div class="flex items-baseline gap-2">
-    <span class="text-foreground text-[13px] font-semibold tabular-nums">{newLastHour}</span>
-    <span class="text-muted-foreground text-[10px] uppercase tracking-wider">novos·1h</span>
-  </div>
-  <div class="bg-border h-4 w-px"></div>
-  <div class="flex items-baseline gap-2">
-    <span
-      class="text-[13px] font-semibold tabular-nums {spiking > 0 ? 'text-amber-400' : 'text-foreground'}"
-    >
-      {spiking}
-    </span>
-    <span class="text-muted-foreground text-[10px] uppercase tracking-wider">spike</span>
-  </div>
-  <div class="bg-border h-4 w-px"></div>
-  <div class="flex items-center gap-3">
-    <div class="flex items-baseline gap-2">
-      <span class="text-foreground text-[13px] font-semibold tabular-nums">{ratePerMin}</span>
-      <span class="text-muted-foreground text-[10px] uppercase tracking-wider">e/min</span>
-    </div>
-    <Sparkline values={buckets} width={72} height={14} accent={ratePerMin > 0} />
-  </div>
+<div class="flex items-center gap-3">
+  <Tooltip.Root>
+    <Tooltip.Trigger>
+      {#snippet child({ props })}
+        <button
+          {...props}
+          type="button"
+          onclick={toggleSince1h}
+          aria-pressed={newActive}
+          aria-label="Filter to issues first seen in the last hour"
+          class={cn(
+            'flex items-baseline gap-1.5 rounded px-1.5 py-0.5 transition-colors',
+            'hover:bg-accent/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+            newActive && 'bg-accent ring-1 ring-border'
+          )}
+        >
+          <AlertTriangle
+            class={cn(
+              'h-3 w-3',
+              newLastHour > 0 ? 'text-amber-400' : 'text-muted-foreground/60'
+            )}
+          />
+          <span
+            class={cn(
+              'text-[13px] font-semibold tabular-nums',
+              newLastHour > 0 ? 'text-foreground' : 'text-muted-foreground'
+            )}
+          >
+            {newLastHour}
+          </span>
+          <span class="text-muted-foreground text-[10px] uppercase tracking-wider">new · 1h</span>
+        </button>
+      {/snippet}
+    </Tooltip.Trigger>
+    <Tooltip.Content>Issues first seen in the last hour. Click to filter.</Tooltip.Content>
+  </Tooltip.Root>
+
+  <Separator orientation="vertical" class="h-4" />
+
+  <Tooltip.Root>
+    <Tooltip.Trigger>
+      {#snippet child({ props })}
+        <button
+          {...props}
+          type="button"
+          onclick={toggleSpiking}
+          aria-pressed={spikeActive}
+          aria-label="Filter to spiking issues"
+          class={cn(
+            'flex items-baseline gap-1.5 rounded px-1.5 py-0.5 transition-colors',
+            'hover:bg-accent/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+            spikeActive && 'bg-accent ring-1 ring-border'
+          )}
+        >
+          <Flame
+            class={cn(
+              'h-3 w-3',
+              spiking > 0 ? 'text-amber-400' : 'text-muted-foreground/60'
+            )}
+          />
+          <span
+            class={cn(
+              'text-[13px] font-semibold tabular-nums',
+              spiking > 0 ? 'text-amber-400' : 'text-muted-foreground'
+            )}
+          >
+            {spiking}
+          </span>
+          <span class="text-muted-foreground text-[10px] uppercase tracking-wider">spiking</span>
+        </button>
+      {/snippet}
+    </Tooltip.Trigger>
+    <Tooltip.Content>Issues whose 5-min rate is at least 3× the prior 5 min. Click to filter.</Tooltip.Content>
+  </Tooltip.Root>
+
+  <Separator orientation="vertical" class="h-4" />
+
+  {#if ingestStale}
+    <Tooltip.Root>
+      <Tooltip.Trigger>
+        {#snippet child({ props })}
+          <Badge {...props} variant="outline" class="gap-1.5 border-amber-500/40 bg-amber-500/10 text-amber-500">
+            <PlugZap class="h-3 w-3" />
+            <span class="text-[10px] uppercase tracking-wider">no ingest</span>
+          </Badge>
+        {/snippet}
+      </Tooltip.Trigger>
+      <Tooltip.Content>
+        {#if eventStream.lastAt == null}
+          No events received yet. Daemon may be running but no SDK has connected.
+        {:else}
+          No events for {Math.round((Date.now() - eventStream.lastAt) / 60_000)} min — check the daemon and SDK config.
+        {/if}
+      </Tooltip.Content>
+    </Tooltip.Root>
+  {:else}
+    <Tooltip.Root>
+      <Tooltip.Trigger>
+        {#snippet child({ props })}
+          <div {...props} class="flex items-center gap-2">
+            <div class="flex items-baseline gap-1.5">
+              <Activity
+                class={cn(
+                  'h-3 w-3',
+                  ratePerMin > 0 ? 'text-foreground' : 'text-muted-foreground/60'
+                )}
+              />
+              <span
+                class={cn(
+                  'text-[13px] font-semibold tabular-nums',
+                  ratePerMin > 0 ? 'text-foreground' : 'text-muted-foreground'
+                )}
+              >
+                {ratePerMin}
+              </span>
+              <span class="text-muted-foreground text-[10px] uppercase tracking-wider">events/min</span>
+            </div>
+            <Sparkline values={buckets} width={96} height={14} accent={ratePerMin > 0} />
+          </div>
+        {/snippet}
+      </Tooltip.Trigger>
+      <Tooltip.Content>Events per minute over the last 5 min, project-wide. Sparkline covers 60 min.</Tooltip.Content>
+    </Tooltip.Root>
+  {/if}
 </div>

--- a/web/src/lib/components/IssueList.svelte
+++ b/web/src/lib/components/IssueList.svelte
@@ -48,6 +48,8 @@
     filter.query = next.query;
     filter.statuses = next.statuses;
     filter.levels = next.levels;
+    filter.sinceMs = next.sinceMs;
+    filter.spikingOnly = next.spikingOnly;
   });
 
   // Push filter state into the URL so the active filter is reload-safe and
@@ -58,7 +60,9 @@
     const params = serializeFilterParams({
       query: filter.query,
       statuses: filter.statuses,
-      levels: filter.levels
+      levels: filter.levels,
+      sinceMs: filter.sinceMs,
+      spikingOnly: filter.spikingOnly
     });
     const search = params.toString();
     const target = location.pathname + (search ? `?${search}` : '') + location.hash;
@@ -67,7 +71,14 @@
     }
   });
 
-  const visible = $derived(visibleIssues());
+  // Re-evaluate when the 5 s tick advances so the since/spiking filters
+  // stay current without each consumer wiring its own setInterval.
+  const visible = $derived.by(() => {
+    void eventStream.tick;
+    return visibleIssues({
+      isSpiking: (id: number) => eventStream.isSpiking(id)
+    });
+  });
 
   type StatusChip = {
     key: IssueStatus;
@@ -113,8 +124,17 @@
     filter.query.trim().length > 0 ||
       filter.statuses.size !== 1 ||
       !filter.statuses.has('unresolved') ||
-      filter.levels.size > 0
+      filter.levels.size > 0 ||
+      filter.sinceMs != null ||
+      filter.spikingOnly
   );
+
+  function sinceLabel(ms: number): string {
+    if (ms === 60 * 60 * 1000) return '1h';
+    if (ms === 24 * 60 * 60 * 1000) return '24h';
+    if (ms === 7 * 24 * 60 * 60 * 1000) return '7d';
+    return `${Math.round(ms / 60000)}m`;
+  }
 
   // Stable, human-readable order for the readout: matches the chip row.
   const STATUS_ORDER: IssueStatus[] = ['unresolved', 'resolved', 'muted', 'ignored'];
@@ -131,6 +151,8 @@
     filter.query = '';
     filter.statuses = new Set<IssueStatus>(['unresolved']);
     filter.levels = new Set<IssueLevel>();
+    filter.sinceMs = null;
+    filter.spikingOnly = false;
   }
 </script>
 
@@ -287,6 +309,15 @@
         <span class="text-border">·</span>
         <span>level:</span>
         <span class="text-foreground">{levelReadout}</span>
+      {/if}
+      {#if filter.sinceMs != null}
+        <span class="text-border">·</span>
+        <span>since:</span>
+        <span class="text-foreground">{sinceLabel(filter.sinceMs)}</span>
+      {/if}
+      {#if filter.spikingOnly}
+        <span class="text-border">·</span>
+        <span class="text-amber-500">spiking only</span>
       {/if}
       <Button
         variant="link"

--- a/web/src/lib/components/ProjectDetail.svelte
+++ b/web/src/lib/components/ProjectDetail.svelte
@@ -17,6 +17,7 @@
   import { eventStream } from '$lib/eventStream.svelte';
   import { projects } from '$lib/stores.svelte';
   import { Button } from '$lib/components/ui/button';
+  import { Collapsible } from '$lib/components/ui/collapsible';
   import { Dialog } from '$lib/components/ui/dialog';
   import { Input } from '$lib/components/ui/input';
   import { Label } from '$lib/components/ui/label';
@@ -292,6 +293,11 @@
   // ----- delete ----------------------------------------------------------
   let deleteOpen = $state(false);
 
+  // Danger zone is collapsed by default — actions inside (rotate / delete)
+  // are once-per-project-lifetime; eating ~30% of the panel for them is
+  // disproportionate to use frequency.
+  let dangerOpen = $state(false);
+
   async function copyCurl() {
     const cmd = buildTestEventCurl(project.dsn);
     try {
@@ -306,8 +312,8 @@
 <div class="flex h-full flex-col overflow-y-auto">
   <div class="mx-auto flex w-full max-w-3xl flex-col gap-7 px-7 py-7">
     <!-- ----- Header strip ----- -->
-    <header class="flex flex-col gap-1.5">
-      <div class="flex items-center gap-2">
+    <header class="flex flex-col gap-2">
+      <div class="flex items-center gap-3">
         {#if renaming}
           <form
             class="flex flex-1 items-center gap-2"
@@ -321,9 +327,9 @@
               autocomplete="off"
               autofocus
               aria-label="New project name"
-              class="h-9 max-w-[280px] font-mono text-[14px]"
+              class="h-10 max-w-[320px] font-mono text-[18px]"
             />
-            <Button type="submit" size="sm" disabled={renameBusy} class="h-9">
+            <Button type="submit" size="sm" disabled={renameBusy} class="h-10">
               {#if renameBusy}
                 <Loader2 class="h-3.5 w-3.5 animate-spin" />
               {:else}
@@ -331,14 +337,16 @@
               {/if}
               Save
             </Button>
-            <Button type="button" variant="ghost" size="sm" onclick={cancelRename} class="h-9">
+            <Button type="button" variant="ghost" size="sm" onclick={cancelRename} class="h-10">
               <X class="h-3.5 w-3.5" />
             </Button>
           </form>
         {:else}
-          <h1 class="font-mono text-[18px] font-semibold tracking-tight">{project.name}</h1>
+          <h1 class="font-mono text-[24px] font-semibold leading-none tracking-tight">
+            {project.name}
+          </h1>
           <span
-            class={cn('h-2 w-2 rounded-full', status.tone)}
+            class={cn('h-2.5 w-2.5 rounded-full', status.tone)}
             title={status.label}
             aria-label={`status: ${status.label}`}
           ></span>
@@ -349,7 +357,7 @@
                   {...props}
                   variant="ghost"
                   size="icon"
-                  class="text-muted-foreground hover:text-foreground ml-1 h-7 w-7"
+                  class="text-muted-foreground hover:text-foreground ml-auto"
                   onclick={startRename}
                   aria-label="Rename project"
                 >
@@ -379,29 +387,53 @@
       <Label id="lbl-activity" class="text-muted-foreground text-[10px] uppercase tracking-wider">
         Activity · last 24h
       </Label>
-      <div class="grid grid-cols-3 gap-3">
-        <div class="border-border bg-card rounded-md border px-3 py-2.5">
-          <div class="text-[18px] font-semibold tabular-nums">
-            {stats ? stats.events_24h.toLocaleString() : '—'}
-          </div>
-          <div class="text-muted-foreground text-[11px]">events 24h</div>
+      {#if stats && stats.events_24h === 0}
+        <!-- First-event empty state. Shows up when the project has never seen
+             traffic; points the user at the primary onboarding CTA below. -->
+        <div class="border-border bg-card flex flex-col items-start gap-1.5 rounded-md border px-4 py-5">
+          <p class="text-[13px] font-medium">No events yet</p>
+          <p class="text-muted-foreground text-[12px]">
+            Paste the DSN below into your SDK or hit
+            <span class="text-foreground font-medium">Send test event</span>
+            to see your first one land here.
+          </p>
         </div>
-        <div class="border-border bg-card rounded-md border px-3 py-2.5">
-          <div class="text-[18px] font-semibold tabular-nums">
-            {#if stats?.last_event_at}{relativeTime(stats.last_event_at)}{:else}—{/if}
+      {:else}
+        <div class="border-border bg-card grid grid-cols-3 gap-0 overflow-hidden rounded-md border">
+          <!-- Primary tile: events 24h. Larger numeric + inline sparkline so the
+               headline metric carries the visual weight; the other two tiles
+               read as compact meta. -->
+          <div class="border-border col-span-2 flex flex-col gap-1.5 border-r px-4 py-3">
+            <div class="flex items-baseline gap-2">
+              <div class="text-[26px] font-semibold leading-none tabular-nums">
+                {stats ? stats.events_24h.toLocaleString() : '—'}
+              </div>
+              <div class="text-muted-foreground text-[11px] uppercase tracking-wider">
+                events 24h
+              </div>
+            </div>
+            <Sparkline values={sparkValues} width={520} height={32} accent class="w-full" />
           </div>
-          <div class="text-muted-foreground text-[11px]">last seen</div>
-        </div>
-        <div class="border-border bg-card rounded-md border px-3 py-2.5">
-          <div class="text-[18px] font-semibold tabular-nums">
-            {stats ? stats.unique_issues_24h.toLocaleString() : '—'}
+          <div class="flex flex-col">
+            <div class="border-border flex flex-col gap-0.5 border-b px-3 py-2">
+              <div class="text-[13px] font-medium tabular-nums">
+                {#if stats?.last_event_at}{relativeTime(stats.last_event_at)}{:else}—{/if}
+              </div>
+              <div class="text-muted-foreground text-[10px] uppercase tracking-wider">
+                last seen
+              </div>
+            </div>
+            <div class="flex flex-col gap-0.5 px-3 py-2">
+              <div class="text-[13px] font-medium tabular-nums">
+                {stats ? stats.unique_issues_24h.toLocaleString() : '—'}
+              </div>
+              <div class="text-muted-foreground text-[10px] uppercase tracking-wider">
+                unique issues
+              </div>
+            </div>
           </div>
-          <div class="text-muted-foreground text-[11px]">unique issues</div>
         </div>
-      </div>
-      <div class="border-border bg-card rounded-md border p-3">
-        <Sparkline values={sparkValues} width={520} height={48} accent class="w-full" />
-      </div>
+      {/if}
       {#if statsError}
         <p class="text-destructive text-[11px]">{statsError}</p>
       {/if}
@@ -462,7 +494,7 @@
           aria-label="Webhook URL"
           class="h-10 flex-1 text-[13px]"
         />
-        <Button variant="outline" onclick={saveWebhook} disabled={savingWebhook} class="h-10">
+        <Button onclick={saveWebhook} disabled={savingWebhook} class="h-10">
           {#if savingWebhook}<Loader2 class="h-4 w-4 animate-spin" />{:else}Save{/if}
         </Button>
         <Tooltip.Root>
@@ -470,7 +502,7 @@
             {#snippet child({ props })}
               <Button
                 {...props}
-                variant="ghost"
+                variant="outline"
                 size="icon"
                 class="h-10 w-10"
                 aria-label="Send a test event to this webhook"
@@ -488,6 +520,11 @@
           <Tooltip.Content side="left">Send a synthetic event to this URL</Tooltip.Content>
         </Tooltip.Root>
       </div>
+      <p class="text-muted-foreground/80 text-[11px]">
+        Slack: <span class="font-mono">hooks.slack.com/services/…</span>
+        · Discord: <span class="font-mono">discord.com/api/webhooks/…</span>
+        · Teams: <span class="font-mono">outlook.office.com/webhook/…</span>
+      </p>
       <p
         class={cn(
           'text-[11px]',
@@ -503,10 +540,23 @@
     <Separator />
 
     <!-- ----- Danger zone ----- -->
-    <section class="flex flex-col gap-3" aria-labelledby="lbl-danger">
-      <Label id="lbl-danger" class="text-destructive text-[10px] uppercase tracking-wider">
-        Danger zone
-      </Label>
+    <Collapsible
+      bind:open={dangerOpen}
+      class="gap-3"
+      triggerClass="px-1 py-1.5"
+      contentClass="mt-3 flex flex-col gap-3"
+    >
+      {#snippet header()}
+        <span
+          id="lbl-danger"
+          class="text-destructive text-[10px] uppercase tracking-wider"
+        >
+          Danger zone
+        </span>
+        <span class="text-muted-foreground/70 ml-2 text-[11px] normal-case tracking-normal">
+          rotate token · delete project
+        </span>
+      {/snippet}
 
       <div class="border-destructive/30 bg-destructive/5 flex items-center justify-between gap-3 rounded-md border p-3">
         <div class="flex flex-col gap-0.5">
@@ -516,11 +566,7 @@
             until you update them.
           </p>
         </div>
-        <Button
-          variant="outline"
-          onclick={openRotate}
-          class="border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive shrink-0"
-        >
+        <Button variant="destructive" onclick={openRotate} class="shrink-0">
           <RotateCcw class="h-3.5 w-3.5" />
           Rotate
         </Button>
@@ -534,16 +580,12 @@
             Cannot be undone.
           </p>
         </div>
-        <Button
-          variant="outline"
-          onclick={() => (deleteOpen = true)}
-          class="border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive shrink-0"
-        >
+        <Button variant="destructive" onclick={() => (deleteOpen = true)} class="shrink-0">
           <Trash2 class="h-3.5 w-3.5" />
           Delete
         </Button>
       </div>
-    </section>
+    </Collapsible>
   </div>
 </div>
 

--- a/web/src/lib/filterUrl.test.ts
+++ b/web/src/lib/filterUrl.test.ts
@@ -10,7 +10,9 @@ describe('serializeFilterParams', () => {
     const p = serializeFilterParams({
       query: '',
       statuses: new Set<IssueStatus>(['unresolved']),
-      levels: new Set<IssueLevel>()
+      levels: new Set<IssueLevel>(),
+      sinceMs: null,
+      spikingOnly: false
     });
     expect(p.has('q')).toBe(false);
   });
@@ -19,7 +21,9 @@ describe('serializeFilterParams', () => {
     const p = serializeFilterParams({
       query: '',
       statuses: new Set<IssueStatus>(['unresolved']),
-      levels: new Set<IssueLevel>()
+      levels: new Set<IssueLevel>(),
+      sinceMs: null,
+      spikingOnly: false
     });
     expect(p.has('s')).toBe(false);
   });
@@ -28,7 +32,9 @@ describe('serializeFilterParams', () => {
     const p = serializeFilterParams({
       query: '',
       statuses: new Set<IssueStatus>(['resolved', 'muted']),
-      levels: new Set<IssueLevel>()
+      levels: new Set<IssueLevel>(),
+      sinceMs: null,
+      spikingOnly: false
     });
     expect(p.get('s')).toBe('muted,resolved');
   });
@@ -37,7 +43,9 @@ describe('serializeFilterParams', () => {
     const p = serializeFilterParams({
       query: '',
       statuses: new Set<IssueStatus>(['unresolved']),
-      levels: new Set<IssueLevel>()
+      levels: new Set<IssueLevel>(),
+      sinceMs: null,
+      spikingOnly: false
     });
     expect(p.has('l')).toBe(false);
   });
@@ -46,7 +54,9 @@ describe('serializeFilterParams', () => {
     const p = serializeFilterParams({
       query: '',
       statuses: new Set<IssueStatus>(['unresolved']),
-      levels: new Set<IssueLevel>(['fatal', 'error'])
+      levels: new Set<IssueLevel>(['fatal', 'error']),
+      sinceMs: null,
+      spikingOnly: false
     });
     expect(p.get('l')).toBe('error,fatal');
   });
@@ -55,7 +65,9 @@ describe('serializeFilterParams', () => {
     const p = serializeFilterParams({
       query: 'auth fail',
       statuses: new Set<IssueStatus>(['unresolved']),
-      levels: new Set<IssueLevel>()
+      levels: new Set<IssueLevel>(),
+      sinceMs: null,
+      spikingOnly: false
     });
     expect(p.get('q')).toBe('auth fail');
   });
@@ -93,12 +105,53 @@ describe('parseFilterParams', () => {
     const initial = {
       query: 'auth',
       statuses: new Set<IssueStatus>(['resolved', 'muted']),
-      levels: new Set<IssueLevel>(['error', 'fatal'])
+      levels: new Set<IssueLevel>(['error', 'fatal']),
+      sinceMs: null,
+      spikingOnly: false
     };
     const round = parseFilterParams(serializeFilterParams(initial));
     expect(round.query).toBe('auth');
     expect([...round.statuses].sort()).toEqual(['muted', 'resolved']);
     expect([...round.levels].sort()).toEqual(['error', 'fatal']);
+  });
+
+  it('round-trips since=1h and spike=1', () => {
+    const round = parseFilterParams(
+      serializeFilterParams({
+        query: '',
+        statuses: new Set<IssueStatus>(['unresolved']),
+        levels: new Set<IssueLevel>(),
+        sinceMs: 60 * 60 * 1000,
+        spikingOnly: true
+      })
+    );
+    expect(round.sinceMs).toBe(60 * 60 * 1000);
+    expect(round.spikingOnly).toBe(true);
+  });
+
+  it('omits since/spike from the URL when defaults', () => {
+    const p = serializeFilterParams({
+      query: '',
+      statuses: new Set<IssueStatus>(['unresolved']),
+      levels: new Set<IssueLevel>(),
+      sinceMs: null,
+      spikingOnly: false
+    });
+    expect(p.has('since')).toBe(false);
+    expect(p.has('spike')).toBe(false);
+  });
+
+  it('parses recognised since presets only (1h, 24h, 7d)', () => {
+    expect(parseFilterParams(new URLSearchParams('since=1h')).sinceMs).toBe(60 * 60 * 1000);
+    expect(parseFilterParams(new URLSearchParams('since=24h')).sinceMs).toBe(24 * 60 * 60 * 1000);
+    expect(parseFilterParams(new URLSearchParams('since=7d')).sinceMs).toBe(7 * 24 * 60 * 60 * 1000);
+    expect(parseFilterParams(new URLSearchParams('since=bogus')).sinceMs).toBeNull();
+  });
+
+  it('parses spike=1 as true; anything else as false', () => {
+    expect(parseFilterParams(new URLSearchParams('spike=1')).spikingOnly).toBe(true);
+    expect(parseFilterParams(new URLSearchParams('spike=0')).spikingOnly).toBe(false);
+    expect(parseFilterParams(new URLSearchParams('')).spikingOnly).toBe(false);
   });
 
   it('treats every recognised status/level as round-trippable', () => {
@@ -107,7 +160,9 @@ describe('parseFilterParams', () => {
         serializeFilterParams({
           query: '',
           statuses: new Set<IssueStatus>([s]),
-          levels: new Set<IssueLevel>()
+          levels: new Set<IssueLevel>(),
+          sinceMs: null,
+          spikingOnly: false
         })
       );
       expect(round.statuses.has(s)).toBe(true);
@@ -117,7 +172,9 @@ describe('parseFilterParams', () => {
         serializeFilterParams({
           query: '',
           statuses: new Set<IssueStatus>(['unresolved']),
-          levels: new Set<IssueLevel>([l])
+          levels: new Set<IssueLevel>([l]),
+          sinceMs: null,
+          spikingOnly: false
         })
       );
       expect(round.levels.has(l)).toBe(true);

--- a/web/src/lib/filterUrl.ts
+++ b/web/src/lib/filterUrl.ts
@@ -8,10 +8,21 @@ export interface FilterState {
   query: string;
   statuses: Set<IssueStatus>;
   levels: Set<IssueLevel>;
+  sinceMs: number | null;
+  spikingOnly: boolean;
 }
 
 const ALL_STATUSES: IssueStatus[] = ['unresolved', 'resolved', 'muted', 'ignored'];
 const ALL_LEVELS: IssueLevel[] = ['debug', 'info', 'warning', 'error', 'fatal'];
+
+// Whitelisted "since" presets. Keeping the URL token symbolic (1h/24h/7d)
+// rather than raw milliseconds means a stale share link can't smuggle in
+// an arbitrary window, and the encoded URL stays human-readable.
+const SINCE_PRESETS: Record<string, number> = {
+  '1h': 60 * 60 * 1000,
+  '24h': 24 * 60 * 60 * 1000,
+  '7d': 7 * 24 * 60 * 60 * 1000
+};
 
 function setEqualsDefaultStatuses(s: Set<IssueStatus>): boolean {
   return s.size === 1 && s.has('unresolved');
@@ -21,11 +32,23 @@ function csvSorted<T extends string>(s: Set<T>): string {
   return [...s].sort().join(',');
 }
 
+function sinceMsToToken(ms: number): string | null {
+  for (const [token, value] of Object.entries(SINCE_PRESETS)) {
+    if (value === ms) return token;
+  }
+  return null;
+}
+
 export function serializeFilterParams(f: FilterState): URLSearchParams {
   const p = new URLSearchParams();
   if (f.query.trim().length > 0) p.set('q', f.query);
   if (!setEqualsDefaultStatuses(f.statuses)) p.set('s', csvSorted(f.statuses));
   if (f.levels.size > 0) p.set('l', csvSorted(f.levels));
+  if (f.sinceMs != null) {
+    const token = sinceMsToToken(f.sinceMs);
+    if (token) p.set('since', token);
+  }
+  if (f.spikingOnly) p.set('spike', '1');
   return p;
 }
 
@@ -59,5 +82,10 @@ export function parseFilterParams(p: URLSearchParams): FilterState {
             .filter((t): t is IssueLevel => (ALL_LEVELS as string[]).includes(t))
         );
 
-  return { query, statuses, levels };
+  const sinceRaw = p.get('since');
+  const sinceMs = sinceRaw != null && sinceRaw in SINCE_PRESETS ? SINCE_PRESETS[sinceRaw]! : null;
+
+  const spikingOnly = p.get('spike') === '1';
+
+  return { query, statuses, levels, sinceMs, spikingOnly };
 }

--- a/web/src/lib/stores.svelte.ts
+++ b/web/src/lib/stores.svelte.ts
@@ -47,6 +47,14 @@ class FilterStore {
   // single-element set, since "no level filter" is the much more common
   // resting state.
   levels = $state<Set<IssueLevel>>(new Set());
+  // Window in ms applied to `first_seen`; null = no since filter. Driven
+  // from header chips ("New (1h)") so the live counters double as filter
+  // entry points.
+  sinceMs = $state<number | null>(null);
+  // When true, visibleIssues drops every issue that is not currently
+  // spiking. The actual spike predicate lives in `eventStream` and is
+  // passed in at call-time to keep this module pure.
+  spikingOnly = $state(false);
 
   toggleStatus(s: IssueStatus) {
     const next = new Set(this.statuses);
@@ -102,9 +110,22 @@ export const load = new LoadStore();
 // IssueUpdated WS messages and persisted in SQLite). Earlier iterations
 // kept this in localStorage; that gave each browser its own truth and was
 // wrong for any team larger than one.
-export function visibleIssues(): Issue[] {
+export interface VisibleIssuesOpts {
+  /** Wall-clock used by the `sinceMs` filter. Defaults to Date.now(). */
+  now?: number;
+  /**
+   * Spike predicate, supplied by the caller (typically backed by
+   * `eventStream.isSpiking`). Kept as a parameter so this module stays
+   * pure and unit-testable without standing up the WS event stream.
+   */
+  isSpiking?: (id: number) => boolean;
+}
+
+export function visibleIssues(opts: VisibleIssuesOpts = {}): Issue[] {
   const q = filter.query.trim().toLowerCase();
   const levelFilter = filter.levels;
+  const now = opts.now ?? Date.now();
+  const sinceCutoff = filter.sinceMs == null ? null : now - filter.sinceMs;
   return issues.list.filter((i) => {
     if (i.project !== projects.current) return false;
     if (!filter.statuses.has(i.status)) return false;
@@ -114,6 +135,15 @@ export function visibleIssues(): Issue[] {
       // dropping them is correct — "show me only fatals" should not
       // accidentally include unlabelled rows.
       if (!(lvl && levelFilter.has(lvl as IssueLevel))) return false;
+    }
+    if (sinceCutoff != null) {
+      const seen = Date.parse(i.first_seen);
+      // Drop rows whose timestamp won't parse rather than risk including
+      // them via a NaN comparison short-circuit.
+      if (!Number.isFinite(seen) || seen < sinceCutoff) return false;
+    }
+    if (filter.spikingOnly) {
+      if (!opts.isSpiking || !opts.isSpiking(i.id)) return false;
     }
     if (q && !matches(i, q)) return false;
     return true;

--- a/web/src/lib/stores.test.ts
+++ b/web/src/lib/stores.test.ts
@@ -33,6 +33,8 @@ beforeEach(() => {
   filter.query = '';
   filter.statuses = new Set<IssueStatus>(['unresolved']);
   filter.levels = new Set<IssueLevel>();
+  filter.sinceMs = null;
+  filter.spikingOnly = false;
   projects.current = 'p';
   selection.issueId = null;
   selection.event = null;
@@ -124,6 +126,66 @@ describe('FilterStore.toggleLevel', () => {
     expect(filter.levels.has('error')).toBe(true);
     filter.toggleLevel('error');
     expect(filter.levels.has('error')).toBe(false);
+  });
+});
+
+describe('visibleIssues + sinceMs filter', () => {
+  const NOW = Date.parse('2026-04-27T12:00:00Z');
+
+  it('keeps every issue when sinceMs is null', () => {
+    issues.reset([
+      issue({ id: 1, first_seen: '2026-04-27T11:30:00Z', status: 'unresolved' }),
+      issue({ id: 2, first_seen: '2026-04-26T00:00:00Z', status: 'unresolved' })
+    ]);
+    filter.sinceMs = null;
+    expect(visibleIssues({ now: NOW }).map((i) => i.id).sort()).toEqual([1, 2]);
+  });
+
+  it('keeps only issues first seen within sinceMs of now', () => {
+    issues.reset([
+      issue({ id: 1, first_seen: '2026-04-27T11:30:00Z', status: 'unresolved' }), // 30 min old
+      issue({ id: 2, first_seen: '2026-04-27T10:30:00Z', status: 'unresolved' }), // 90 min old
+      issue({ id: 3, first_seen: '2026-04-27T11:59:30Z', status: 'unresolved' })  //  30s old
+    ]);
+    filter.sinceMs = 60 * 60 * 1000; // 1h
+    expect(visibleIssues({ now: NOW }).map((i) => i.id).sort()).toEqual([1, 3]);
+  });
+
+  it('drops issues with malformed first_seen when a since filter is active', () => {
+    issues.reset([
+      issue({ id: 1, first_seen: 'not-a-date', status: 'unresolved' }),
+      issue({ id: 2, first_seen: '2026-04-27T11:30:00Z', status: 'unresolved' })
+    ]);
+    filter.sinceMs = 60 * 60 * 1000;
+    expect(visibleIssues({ now: NOW }).map((i) => i.id)).toEqual([2]);
+  });
+});
+
+describe('visibleIssues + spikingOnly filter', () => {
+  it('passes through when spikingOnly is false', () => {
+    issues.reset([
+      issue({ id: 1, status: 'unresolved' }),
+      issue({ id: 2, status: 'unresolved' })
+    ]);
+    filter.spikingOnly = false;
+    expect(visibleIssues({ isSpiking: () => false }).map((i) => i.id).sort()).toEqual([1, 2]);
+  });
+
+  it('keeps only issues for which the predicate returns true', () => {
+    issues.reset([
+      issue({ id: 1, status: 'unresolved' }),
+      issue({ id: 2, status: 'unresolved' }),
+      issue({ id: 3, status: 'unresolved' })
+    ]);
+    filter.spikingOnly = true;
+    const isSpiking = (id: number) => id === 2;
+    expect(visibleIssues({ isSpiking }).map((i) => i.id)).toEqual([2]);
+  });
+
+  it('treats a missing predicate as nothing-spikes when spikingOnly is true', () => {
+    issues.reset([issue({ id: 1, status: 'unresolved' })]);
+    filter.spikingOnly = true;
+    expect(visibleIssues().map((i) => i.id)).toEqual([]);
   });
 });
 

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -16,6 +16,7 @@
   import ProjectSelector from '$lib/components/ProjectSelector.svelte';
   import Toaster from '$lib/components/Toaster.svelte';
   import { Button } from '$lib/components/ui/button';
+  import { Separator } from '$lib/components/ui/separator';
   import * as Tooltip from '$lib/components/ui/tooltip';
   import { toast } from '$lib/toast.svelte';
   import { cn } from '$lib/utils';
@@ -117,15 +118,18 @@
   {:else}
     <div class="flex h-screen">
       <aside
-        class="border-border bg-background flex w-14 shrink-0 flex-col items-center gap-3 border-r py-4"
+        class="border-border bg-background flex w-16 shrink-0 flex-col items-center gap-1.5 border-r py-3"
       >
+        <!-- Brand mark. Contained square so the orange reads as identity, not
+             alarm — keeps the active-nav rail as the only orange "you are
+             here" signal in the sidebar. -->
         <a
           href="/"
-          class="text-primary inline-flex h-10 w-10 items-center justify-center rounded-md"
+          class="bg-primary/10 text-primary hover:bg-primary/15 mb-2 inline-flex h-10 w-10 items-center justify-center rounded-lg transition-colors"
           aria-label="errex"
           title="errex"
         >
-          <AlertCircle class="h-[18px] w-[18px]" />
+          <AlertCircle class="h-5 w-5" strokeWidth={2.25} />
         </a>
 
         <Tooltip.Root>
@@ -136,10 +140,10 @@
                 variant="ghost"
                 size="icon"
                 onclick={() => (paletteOpen = true)}
-                class="text-muted-foreground hover:text-foreground h-10 w-10"
+                class="text-muted-foreground hover:text-foreground h-10 w-10 rounded-lg"
                 aria-label="Search"
               >
-                <Search class="h-[18px] w-[18px]" />
+                <Search class="h-5 w-5" strokeWidth={1.75} />
               </Button>
             {/snippet}
           </Tooltip.Trigger>
@@ -155,12 +159,19 @@
                 {...props}
                 href="/projects"
                 class={cn(
-                  'text-muted-foreground hover:text-foreground hover:bg-accent inline-flex h-10 w-10 items-center justify-center rounded-md transition-colors',
+                  'text-muted-foreground hover:text-foreground hover:bg-accent relative inline-flex h-10 w-10 items-center justify-center rounded-lg transition-colors',
                   onProjectsRoute && 'bg-accent text-foreground'
                 )}
                 aria-label="Projects"
+                aria-current={onProjectsRoute ? 'page' : undefined}
               >
-                <Boxes class="h-[18px] w-[18px]" />
+                {#if onProjectsRoute}
+                  <span
+                    class="bg-primary absolute top-1/2 -left-3 h-5 w-0.5 -translate-y-1/2 rounded-r-full"
+                    aria-hidden="true"
+                  ></span>
+                {/if}
+                <Boxes class="h-5 w-5" strokeWidth={1.75} />
               </a>
             {/snippet}
           </Tooltip.Trigger>
@@ -175,12 +186,19 @@
                   {...props}
                   href="/team"
                   class={cn(
-                    'text-muted-foreground hover:text-foreground hover:bg-accent inline-flex h-10 w-10 items-center justify-center rounded-md transition-colors',
+                    'text-muted-foreground hover:text-foreground hover:bg-accent relative inline-flex h-10 w-10 items-center justify-center rounded-lg transition-colors',
                     onTeamRoute && 'bg-accent text-foreground'
                   )}
                   aria-label="Team"
+                  aria-current={onTeamRoute ? 'page' : undefined}
                 >
-                  <Users class="h-[18px] w-[18px]" />
+                  {#if onTeamRoute}
+                    <span
+                      class="bg-primary absolute top-1/2 -left-3 h-5 w-0.5 -translate-y-1/2 rounded-r-full"
+                      aria-hidden="true"
+                    ></span>
+                  {/if}
+                  <Users class="h-5 w-5" strokeWidth={1.75} />
                 </a>
               {/snippet}
             </Tooltip.Trigger>
@@ -188,7 +206,8 @@
           </Tooltip.Root>
         {/if}
 
-        <div class="mt-auto flex flex-col items-center gap-3">
+        <div class="mt-auto flex w-full flex-col items-center gap-1">
+          <Separator class="bg-border/60 mb-1 w-7" />
           <Freshness />
           <ConnectionStatus />
         </div>
@@ -196,7 +215,7 @@
 
       <div class="flex min-w-0 flex-1 flex-col">
         <header
-          class="border-border bg-background flex h-11 shrink-0 items-center gap-4 border-b px-5"
+          class="border-border bg-background flex h-11 shrink-0 items-center gap-3 border-b px-3"
         >
           {#if onProjectsRoute}
             <span class="text-muted-foreground inline-flex items-center text-[12px] tracking-tight">
@@ -222,9 +241,9 @@
             <span class="text-muted-foreground inline-flex items-center text-[12px] tracking-tight">
               <ProjectSelector variant="inline" />
               <span class="px-1.5 opacity-50">/</span>
-              Issues
+              <a href="/" class="hover:text-foreground transition-colors">Issues</a>
             </span>
-            <div class="bg-border h-4 w-px"></div>
+            <Separator orientation="vertical" class="h-4" />
             <HeaderStats />
           {/if}
 


### PR DESCRIPTION
## Summary
- Adds `since` and `spikingOnly` filters end-to-end (URL params, stores, IssueList, HeaderStats).
- Reworks `ProjectDetail` per design critique: bigger h1, primary `events 24h` tile with inline sparkline, empty-state card when no events, fixed button hierarchy, webhook URL hints, collapsed danger zone.

## Test plan
- [ ] `bun run check` clean
- [ ] `bun run test` (170 tests) green
- [ ] Visit `/projects/<name>`: header h1 dominant, activity tile dominant, danger zone collapsed by default
- [ ] Brand-new project shows "No events yet" card pointing at Send test event
- [ ] Webhook Save renders filled primary; Rotate/Delete render filled red
- [ ] `since` and `spikingOnly` filters round-trip through URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)